### PR TITLE
fix: adversarial review auth — pass API key as action input

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -87,5 +87,4 @@ jobs:
 
             Post your findings as a PR review comment. If nothing concerning is found,
             post a brief "Security review: no issues found" comment.
-        env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Fix: pass `anthropic_api_key` as a `with:` input instead of `env:` variable
- The action tried OIDC token exchange (which fails) because it didn't see an API key input
- This is why the adversarial review has failed on every PR since it was introduced

## Test plan

- [ ] CI passes
- [ ] `adversarial-review` check actually runs and posts a review comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)