### PR TITLE
fix: switch adversarial review to pull_request trigger

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: PR Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Summary

- Switch from `pull_request_target` to `pull_request` in pr-review.yml
- Root cause: `pull_request_target` OIDC tokens are rejected by the Claude Code GitHub App's auth flow ("Invalid OIDC token" on every PR)
- The adversarial reviewer has never successfully run due to this issue

## Security tradeoff

`pull_request_target` ran the workflow from main (immutable prompt). `pull_request` runs from the PR branch. Remaining mitigations:
- `instruction-integrity` job flags changes to workflow files
- Manual merge by project owner
- No external contributors / untrusted forks

## Test plan

- [ ] CI passes
- [ ] **adversarial-review check actually runs and posts a comment** (first time ever!)

🤖 Generated with [Claude Code](https://claude.com/claude-code)