### PR TITLE
fix: allow dependabot to trigger adversarial PR review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -59,6 +59,7 @@ jobs:
           fetch-depth: 0
       - uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185  # v1
         with:
+          allowed_bots: "dependabot[bot]"
           # This prompt is intentionally defined here, NOT read from CLAUDE.md.
           # It runs via pull_request_target so the workflow version from main
           # is always used, even if the PR modifies this file.


### PR DESCRIPTION
## Summary
- claude-code-action now blocks bot-initiated PRs by default, causing dependabot PRs to fail the adversarial review check
- Adds `dependabot[bot]` to `allowed_bots` so dependency update PRs get the same security review as human-authored PRs
- Uses a targeted allowlist (not `*`) to avoid cost exposure from arbitrary bots on a public repo

## Test plan
- [ ] Merge and verify the next dependabot PR passes the adversarial-review job
- [ ] Confirm human-authored PRs still trigger the review as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)