### PR TITLE
fix: use pull_request_target trigger for adversarial review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,7 +1,7 @@
 name: PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Summary
- The adversarial review workflow uses `pull_request` trigger, which blocks secret access for dependabot-initiated PRs (GitHub security restriction)
- Changes to `pull_request_target`, which runs the workflow from main's copy (tamper-proof) and grants access to the `ANTHROPIC_API_KEY` secret
- This is safe because neither job executes PR code — `instruction-integrity` uses `gh pr diff` (API call) and `adversarial-review` uses claude-code-action which reads the diff via API

## Test plan
- [ ] Merge this PR, then re-run adversarial-review on an open dependabot PR to confirm it passes
- [ ] Verify human-authored PRs still trigger the review

🤖 Generated with [Claude Code](https://claude.com/claude-code)