### PR TITLE
feat: osoji init with interactive provider selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
-# Osoji environment configuration
-# Copy to .env and fill in your values (never commit .env!)
+# Osoji environment -- copy to .env and fill in your values
+# .env is gitignored and loaded automatically by the osoji CLI
 
-# Default provider is anthropic if OSOJI_PROVIDER is unset.
-OSOJI_PROVIDER=anthropic
+# Required for `osoji push` -- your osoji-teams API token
+# OSOJI_TOKEN=
+
+# Override provider from config file (default: anthropic).
+# Supported: anthropic, openai, google, openrouter, claude-code
+# OSOJI_PROVIDER=anthropic
 
 # Set one model for every tier, or override tiers individually.
 # OSOJI_MODEL=
@@ -10,6 +14,7 @@ OSOJI_PROVIDER=anthropic
 # OSOJI_MODEL_MEDIUM=
 # OSOJI_MODEL_LARGE=
 
+# Required for `osoji shadow`, `osoji audit`, etc. -- your LLM provider API key
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 GEMINI_API_KEY=

--- a/.osoji.local.toml.example
+++ b/.osoji.local.toml.example
@@ -1,0 +1,30 @@
+# Local overrides -- copy to .osoji.local.toml
+# .osoji.local.toml is gitignored; use it to override LLM provider/model
+# settings and push config on your machine.
+#
+# For secrets (API keys, tokens), use .env instead.
+
+# Override the default LLM provider (default: anthropic)
+# Options: anthropic, openai, google, openrouter, claude-code
+# default_provider = "openai"
+
+# Per-provider model overrides (small = fast/cheap, medium = balanced, large = most capable)
+# [providers.anthropic]
+# small  = "claude-haiku-4-5-20251001"
+# medium = "claude-sonnet-4-6"
+# large  = "claude-opus-4-6"
+
+# [providers.openai]
+# small  = "gpt-5-mini"
+# medium = "gpt-5.2"
+# large  = "gpt-5.4"
+
+# claude-code provider routes through the locally installed Claude Code CLI.
+# Model overrides are passed via --model flag to the CLI.
+# [providers.claude-code]
+# medium = "claude-sonnet-4-6"
+
+# Local push config overrides (e.g. push to a staging endpoint)
+# [push]
+# endpoint = "https://staging.osojicode.ai"
+# project = "my-fork"

--- a/.osoji.toml
+++ b/.osoji.toml
@@ -1,2 +1,5 @@
+default_provider = "anthropic"
+
 [push]
 endpoint = "https://api.osojicode.ai"
+project = "osoji"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ export analysis, and string contract checking.
 
 ## Key architecture
 
-- `src/osoji/cli.py` — Click CLI with subcommands: `shadow`, `check` (`--dry-run`), `diff`, `stats`, `audit`, `report`, `export`, `push`, `hooks`, `safety`, `config show`, `skills list|show`
+- `src/osoji/cli.py` — Click CLI with subcommands: `init`, `shadow`, `check` (`--dry-run`), `diff`, `stats`, `audit`, `report`, `export`, `push`, `hooks`, `safety`, `config show`, `skills list|show`
+- `src/osoji/init.py` — Interactive project setup (gitignore, .env, .osoji.toml merge)
 - `src/osoji/config.py` — Configuration, path helpers, model tier constants
 - `src/osoji/shadow.py` — Core shadow doc generation engine
 - `src/osoji/audit.py` — Multi-phase audit orchestration
@@ -116,9 +117,11 @@ the bundle shape produced by `osoji export`. It uses JSON Schema Draft 2020-12.
 The `osoji push` command reads `[push]` config from three files (later overrides earlier):
 - `~/.config/osoji/config.toml` — global defaults
 - `.osoji.toml` — committed project config (project, endpoint)
-- `.osoji.local.toml` — gitignored local overrides (token, custom endpoint)
+- `.osoji.local.toml` — gitignored local overrides (endpoint, project)
 
 CLI flags and environment variables (`OSOJI_ENDPOINT`, `OSOJI_TOKEN`) take highest precedence.
+Secrets (`OSOJI_TOKEN`, API keys) go in `.env` — loaded automatically, never committed.
+In non-quiet mode, `osoji push` prints which source each config value was resolved from.
 
 ## LLM parameters
 

--- a/docs/superpowers/specs/2026-04-11-provider-selection-init-design.md
+++ b/docs/superpowers/specs/2026-04-11-provider-selection-init-design.md
@@ -1,0 +1,181 @@
+# Provider Selection in `osoji init`
+
+## Context
+
+The current `osoji init` flow hardcodes Anthropic as the default provider and
+doesn't offer interactive selection. Users who want to use OpenAI, Google
+Gemini, OpenRouter, or Claude Code must know to pass `--provider` or edit
+config files manually. This doesn't advertise multi-provider support and gives
+no guidance on switching providers or deferring API key setup.
+
+**Goal:** Let users interactively choose from all supported providers during
+init, see sensible model defaults, decide where config lives (shared vs
+personal), and receive clear guidance on how to change things later.
+
+## Design
+
+### Phase Restructure
+
+The init flow goes from 3 phases to 4:
+
+| Phase | Name | Purpose |
+|-------|------|---------|
+| 1 | Git hygiene | .gitignore entries (unchanged) |
+| 2 | **Provider setup** | **NEW** — provider selection, model defaults, config target |
+| 3 | Secrets (.env) | API key for selected provider, OSOJI_TOKEN |
+| 4 | Project config | .osoji.toml project slug (unchanged) |
+
+### Phase 2: Provider Setup (interactive)
+
+**Provider selection** — numbered list, default 1 (Anthropic):
+
+```
+2. Provider setup
+
+   Choose your LLM provider:
+
+     1. Anthropic         Claude models, built-in defaults
+     2. OpenAI            GPT models, built-in defaults
+     3. Google Gemini     Gemini models, built-in defaults
+     4. OpenRouter        Multi-provider gateway, built-in defaults
+     5. Claude Code CLI   Uses your Claude Code subscription (no API key needed)
+
+   Provider [1]:
+```
+
+When `--provider` is passed on CLI, skip the selection prompt and use it
+directly — print `Provider: {display_name} (from --provider flag)`.
+
+**Model defaults display** — show the built-in tier defaults for the chosen
+provider and let the user accept or override:
+
+```
+   Model defaults for Anthropic:
+     small:  claude-haiku-4-5-20251001
+     medium: claude-sonnet-4-6
+     large:  claude-opus-4-6
+   Accept defaults? [Y/n]:
+```
+
+If the user declines, prompt for each tier with the current default pre-filled:
+
+```
+   small model [claude-haiku-4-5-20251001]:
+   medium model [claude-sonnet-4-6]:
+   large model [claude-opus-4-6]:
+```
+
+For **Claude Code**: skip model defaults entirely — it manages models
+internally. Print: `Claude Code manages model selection internally.`
+
+**Config target** — ask where to save provider config:
+
+```
+   Save provider config to:
+     1. .osoji.toml        Shared with team, committed to git (Recommended)
+     2. .osoji.local.toml  Personal, gitignored
+
+   Config target [1]:
+```
+
+Write the chosen provider to the selected file as `default_provider`:
+
+```toml
+default_provider = "anthropic"
+```
+
+Only write model overrides if the user changed a default (don't persist values
+that match the built-in defaults — they'd just go stale):
+
+```toml
+default_provider = "openai"
+
+[providers.openai]
+small = "gpt-5-mini"
+medium = "gpt-5.2"
+large = "gpt-5.4"
+```
+
+**Post-setup guidance** — after Phase 2 completes:
+
+```
+   Tip: To switch providers later, set default_provider in your config file:
+     default_provider = "openai"
+
+   Or set OSOJI_PROVIDER and OSOJI_MODEL environment variables.
+   Run `osoji config show` to see your current configuration.
+```
+
+### Phase 3: Secrets (.env)
+
+Behavior adjusts based on the provider selected in Phase 2:
+
+- **API-key providers** (anthropic, openai, google, openrouter): prompt for the
+  provider's `api_key_env` as before. If skipped, print:
+  ```
+     Skipped. Add your API key later in .env:
+       ANTHROPIC_API_KEY=sk-...
+  ```
+
+- **Claude Code**: skip API key prompt entirely, print:
+  ```
+     Claude Code uses your existing subscription. No API key needed.
+  ```
+
+- OSOJI_TOKEN prompt is unchanged (always shown).
+
+### Non-interactive Mode (`--non-interactive`)
+
+- Provider from `--provider` flag (default: anthropic)
+- Built-in model defaults used, no prompts
+- Provider config written to `.osoji.toml` (shared target)
+- API key placeholder written to `.env`
+- Summary: `Provider: Anthropic (built-in defaults)`
+
+### Built-in Model Defaults
+
+All providers now have built-in defaults in `BUILTIN_PROVIDER_MODELS`:
+
+| Provider | Small | Medium | Large |
+|----------|-------|--------|-------|
+| anthropic | claude-haiku-4-5-20251001 | claude-sonnet-4-6 | claude-opus-4-6 |
+| openai | gpt-5-mini | gpt-5.2 | gpt-5.4 |
+| google | gemini-3.1-flash-lite-preview | gemini-3-flash-preview | gemini-3.1-pro-preview |
+| openrouter | anthropic/claude-haiku-4.5 | anthropic/claude-sonnet-4.6 | anthropic/claude-opus-4.6 |
+| claude-code | *(same as anthropic)* | | |
+
+OpenRouter defaults to Anthropic models via the gateway for tool-use prompt
+compatibility. Users can override with any OpenRouter-available model.
+
+Google defaults use the 3.x preview series (latest as of April 2026). The 2.5
+series is scheduled for deprecation June 2026.
+
+## Files to Modify
+
+- **`src/osoji/init.py`** — restructure into 4 phases; add provider selection
+  (numbered list), model defaults display/override, config target choice; update
+  guidance text; adjust Phase 3 to be provider-aware
+- **`src/osoji/config.py`** — add `GOOGLE_MODEL_SMALL/MEDIUM/LARGE` and
+  `OPENROUTER_MODEL_SMALL/MEDIUM/LARGE` constants; add google and openrouter
+  entries to `BUILTIN_PROVIDER_MODELS`
+- **`src/osoji/llm/registry.py`** — set `requires_explicit_model=False` for
+  google and openrouter (they now have built-in defaults)
+- **`tests/test_init.py`** — update existing tests for 4-phase structure; add
+  tests for provider selection, model override, config target choice, claude-code
+  path, non-interactive with provider flag
+- **`.env.example`** — document all provider API key env vars
+
+No new files. No new dependencies.
+
+## Verification
+
+1. `pytest tests/test_init.py -v` — all init tests pass
+2. `osoji init .` interactive — walk through provider selection, model defaults,
+   config target, API key, and project slug; verify `.osoji.toml` (or
+   `.osoji.local.toml`) and `.env` contain correct values
+3. `osoji init . --non-interactive` — verify defaults written correctly
+4. `osoji init . --provider openai` — verify skips selection, shows OpenAI flow
+5. `osoji init . --provider claude-code` — verify no API key prompt
+6. Rerun `osoji init .` on an already-initialized project — verify idempotent
+   (skips existing keys, merges cleanly)
+7. `osoji config show` — verify provider config is read back correctly

--- a/docs/tutorials/getting-started-cli.md
+++ b/docs/tutorials/getting-started-cli.md
@@ -157,8 +157,41 @@ At this point you should be able to:
 2. Run `osoji --help` and see the subcommand list above.
 3. Have your LLM API key exported in the current shell.
 
-If all three check out, you are ready to generate your first shadow
-documentation.
+If all three check out, you are ready to set up your project.
+
+---
+
+## Step 2b: Initialize your project (recommended)
+
+Run `osoji init` to set up configuration for your project:
+
+```bash
+osoji init
+```
+
+This walks you through:
+- Adding osoji entries to `.gitignore` (`.osoji/`, `.osoji.local.toml`, `.env`)
+- Setting your LLM API key in `.env`
+- Configuring a project slug in `.osoji.toml` for `osoji push`
+
+Each step prompts for confirmation with sensible defaults -- press Enter to
+accept them all.
+
+For scripted or CI environments, use `--non-interactive` to write template
+files with commented-out placeholders:
+
+```bash
+osoji init --non-interactive
+```
+
+If you use a provider other than Anthropic:
+
+```bash
+osoji init --provider openai
+```
+
+If you already have a `.env` or `.osoji.toml`, `osoji init` will merge missing
+keys without overwriting existing values.
 
 ---
 
@@ -695,6 +728,9 @@ osoji push --token $OSOJI_TOKEN --endpoint https://custom.endpoint/api
 Push configuration is read from `~/.config/osoji/config.toml`,
 `.osoji.toml`, and `.osoji.local.toml`, with CLI flags and environment
 variables (`OSOJI_ENDPOINT`, `OSOJI_TOKEN`) taking highest precedence.
+Secrets (`OSOJI_TOKEN`, API keys) go in `.env` -- loaded automatically,
+never committed. In non-quiet mode, `osoji push` prints which source each
+config value was resolved from.
 
 ---
 

--- a/requirements.lock
+++ b/requirements.lock
@@ -1240,7 +1240,9 @@ pygments==2.20.0 \
 python-dotenv==1.2.2 \
     --hash=sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a \
     --hash=sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3
-    # via litellm
+    # via
+    #   osojicode (pyproject.toml)
+    #   litellm
 pyyaml==6.0.3 \
     --hash=sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c \
     --hash=sha256:0150219816b6a1fa26fb4699fb7daa9caf09eb1999f3b70fb6e786805e80375a \

--- a/src/osoji/cli.py
+++ b/src/osoji/cli.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import click
+from dotenv import load_dotenv
 
 from .audit import run_audit, format_audit_report, format_audit_json, format_audit_html, load_audit_result
 from .config import Config
@@ -14,6 +15,7 @@ from .stats import gather_stats, format_stats_report
 from .observatory import write_observatory_bundle
 from .hooks import install_hooks, uninstall_hooks
 from .push import run_push
+from .init import run_init
 from .llm import provider_names
 from .safety import check_staged_files, check_files as safety_check_files
 from .safety.checker import format_check_result
@@ -80,9 +82,34 @@ def main(ctx: click.Context, verbose: bool, quiet: bool) -> None:
     Audit your project for dead code, stale documentation, and semantic
     contradictions. Ships with agent skill files for automated triage and fixing.
     """
+    load_dotenv()  # Load .env before any subcommand (does not override existing env vars)
     if verbose and quiet:
         raise click.UsageError("Cannot use --verbose and --quiet together.")
     ctx.obj = CLIState(verbose=verbose, quiet=quiet)
+
+
+@main.command()
+@click.argument("path", type=click.Path(exists=True, file_okay=False, path_type=Path), default=".")
+@click.option("--non-interactive", is_flag=True, help="Skip prompts, write templates with placeholders")
+@click.option("--provider", type=_LLM_PROVIDER_CHOICE, default="anthropic", help="LLM provider (determines which API key to configure)")
+def init(path: Path, non_interactive: bool, provider: str) -> None:
+    """Set up osoji for this project.
+
+    Creates or updates .gitignore, .env, and .osoji.toml with sensible
+    defaults. Prompts for API keys and project config interactively.
+
+    \b
+    Examples:
+        osoji init                          # Interactive setup
+        osoji init --non-interactive        # Write templates without prompting
+        osoji init --provider openai        # Configure for OpenAI instead
+        osoji init /path/to/project         # Init a specific directory
+    """
+    run_init(
+        root=path.resolve(),
+        interactive=not non_interactive,
+        provider=provider,
+    )
 
 
 @main.command()

--- a/src/osoji/config.py
+++ b/src/osoji/config.py
@@ -147,6 +147,14 @@ OPENAI_MODEL_SMALL = "gpt-5-mini"
 OPENAI_MODEL_MEDIUM = "gpt-5.2"
 OPENAI_MODEL_LARGE = "gpt-5.4"
 
+GOOGLE_MODEL_SMALL = "gemini-3.1-flash-lite-preview"
+GOOGLE_MODEL_MEDIUM = "gemini-3-flash-preview"
+GOOGLE_MODEL_LARGE = "gemini-3.1-pro-preview"
+
+OPENROUTER_MODEL_SMALL = "anthropic/claude-haiku-4.5"
+OPENROUTER_MODEL_MEDIUM = "anthropic/claude-sonnet-4.6"
+OPENROUTER_MODEL_LARGE = "anthropic/claude-opus-4.6"
+
 BUILTIN_PROVIDER_MODELS: dict[str, dict[str, str]] = {
     "anthropic": {
         "small": ANTHROPIC_MODEL_SMALL,
@@ -158,10 +166,20 @@ BUILTIN_PROVIDER_MODELS: dict[str, dict[str, str]] = {
         "medium": ANTHROPIC_MODEL_MEDIUM,
         "large": ANTHROPIC_MODEL_LARGE,
     },
+    "google": {
+        "small": GOOGLE_MODEL_SMALL,
+        "medium": GOOGLE_MODEL_MEDIUM,
+        "large": GOOGLE_MODEL_LARGE,
+    },
     "openai": {
         "small": OPENAI_MODEL_SMALL,
         "medium": OPENAI_MODEL_MEDIUM,
         "large": OPENAI_MODEL_LARGE,
+    },
+    "openrouter": {
+        "small": OPENROUTER_MODEL_SMALL,
+        "medium": OPENROUTER_MODEL_MEDIUM,
+        "large": OPENROUTER_MODEL_LARGE,
     },
 }
 

--- a/src/osoji/init.py
+++ b/src/osoji/init.py
@@ -85,9 +85,20 @@ def merge_dotenv(root: Path, values: dict[str, str]) -> list[dict[str, str]]:
     actions: list[dict[str, str]] = []
     lines_to_add: list[str] = []
 
+    # Also track commented-out placeholders to avoid duplicating them
+    commented_keys: set[str] = set()
+    if original:
+        for line in original.splitlines():
+            stripped = line.strip()
+            cm = re.match(r"#\s*([A-Za-z_][A-Za-z0-9_]*)=", stripped)
+            if cm:
+                commented_keys.add(cm.group(1))
+
     for key, value in values.items():
         if key in existing_keys:
             actions.append({"key": key, "action": "skipped", "reason": "already set in .env"})
+        elif not value and key in commented_keys:
+            actions.append({"key": key, "action": "skipped", "reason": "placeholder already in .env"})
         else:
             if value:
                 lines_to_add.append(f"{key}={value}")
@@ -195,12 +206,12 @@ def run_init(
             with open(gitignore_path, "a", encoding="utf-8") as f:
                 f.write("\n".join(parts))
             for pattern, _ in entries_to_add:
-                click.echo(f"   {click.style('✓', fg='green')} Added {pattern}")
+                click.echo(f"   {click.style('ok', fg='green')} Added {pattern}")
     else:
         actions = merge_gitignore(root)
         for a in actions:
             if a["action"] == "added":
-                click.echo(f"   {click.style('✓', fg='green')} Added {a['entry']}")
+                click.echo(f"   {click.style('ok', fg='green')} Added {a['entry']}")
             else:
                 click.echo(f"   Already in .gitignore: {a['entry']}")
 
@@ -238,7 +249,7 @@ def run_init(
             env_actions = merge_dotenv(root, env_values)
             for a in env_actions:
                 if a["action"] == "added":
-                    click.echo(f"   {click.style('✓', fg='green')} Added {a['key']} to .env")
+                    click.echo(f"   {click.style('ok', fg='green')} Added {a['key']} to .env")
                 else:
                     click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
         elif not existing_keys:
@@ -250,7 +261,7 @@ def run_init(
         actions = merge_dotenv(root, env_values)
         for a in actions:
             if a["action"] == "added":
-                click.echo(f"   {click.style('✓', fg='green')} Added {a['key']} to .env (placeholder)")
+                click.echo(f"   {click.style('ok', fg='green')} Added {a['key']} to .env (placeholder)")
             else:
                 click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
 
@@ -273,7 +284,7 @@ def run_init(
     toml_actions = merge_project_toml(root, project_slug=project_slug)
     for a in toml_actions:
         if a["action"] == "added":
-            click.echo(f"   {click.style('✓', fg='green')} Set [push] project = \"{project_slug}\" in .osoji.toml")
+            click.echo(f"   {click.style('ok', fg='green')} Set [push] project = \"{project_slug}\" in .osoji.toml")
         else:
             click.echo(f"   Skipping {a['key']} ({a['reason']})")
 

--- a/src/osoji/init.py
+++ b/src/osoji/init.py
@@ -1,0 +1,139 @@
+"""Interactive project setup for Osoji."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from .config import PROJECT_CONFIG_FILENAME
+
+_GITIGNORE_ENTRIES: list[tuple[str, str]] = [
+    (".osoji/", "intermediate results and derived data"),
+    (".osoji.local.toml", "local config overrides"),
+    (".env", "secrets file"),
+]
+
+
+def merge_gitignore(root: Path) -> list[dict[str, str]]:
+    """Ensure .gitignore has osoji entries. Returns actions taken per entry."""
+
+    gitignore_path = root / ".gitignore"
+    existing_lines: set[str] = set()
+    original = ""
+
+    if gitignore_path.exists():
+        original = gitignore_path.read_text(encoding="utf-8")
+        existing_lines = {line.strip() for line in original.splitlines()}
+
+    actions: list[dict[str, str]] = []
+    to_add: list[str] = []
+
+    for pattern, description in _GITIGNORE_ENTRIES:
+        if pattern in existing_lines:
+            actions.append({"entry": pattern, "action": "skipped", "reason": "already in .gitignore"})
+        else:
+            to_add.append(pattern)
+            actions.append({"entry": pattern, "action": "added", "description": description})
+
+    if to_add:
+        lines: list[str] = []
+        if original and not original.endswith("\n"):
+            lines.append("")
+        lines.append("")
+        lines.append("# Osoji")
+        lines.extend(to_add)
+        lines.append("")
+
+        with open(gitignore_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+
+    return actions
+
+
+def _parse_env_keys(content: str) -> set[str]:
+    """Extract active (non-commented) variable names from .env content."""
+
+    keys: set[str] = set()
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            match = re.match(r"([A-Za-z_][A-Za-z0-9_]*)=", stripped)
+            if match:
+                keys.add(match.group(1))
+    return keys
+
+
+def merge_dotenv(root: Path, values: dict[str, str]) -> list[dict[str, str]]:
+    """Merge key=value pairs into .env, skipping keys already present.
+
+    Empty values are written as commented-out lines (# KEY=).
+    """
+
+    env_path = root / ".env"
+    existing_keys: set[str] = set()
+    original = ""
+
+    if env_path.exists():
+        original = env_path.read_text(encoding="utf-8")
+        existing_keys = _parse_env_keys(original)
+
+    actions: list[dict[str, str]] = []
+    lines_to_add: list[str] = []
+
+    for key, value in values.items():
+        if key in existing_keys:
+            actions.append({"key": key, "action": "skipped", "reason": "already set in .env"})
+        else:
+            if value:
+                lines_to_add.append(f"{key}={value}")
+            else:
+                lines_to_add.append(f"# {key}=")
+            actions.append({"key": key, "action": "added"})
+
+    if lines_to_add:
+        parts: list[str] = []
+        if original and not original.endswith("\n"):
+            parts.append("")
+        parts.extend(lines_to_add)
+        parts.append("")
+
+        with open(env_path, "a", encoding="utf-8") as f:
+            f.write("\n".join(parts))
+
+    return actions
+
+
+def merge_project_toml(root: Path, *, project_slug: str | None) -> list[dict[str, str]]:
+    """Ensure .osoji.toml has a [push] project entry."""
+
+    if not project_slug:
+        return [{"key": "push.project", "action": "skipped", "reason": "no project slug provided"}]
+
+    toml_path = root / PROJECT_CONFIG_FILENAME
+    existing: dict = {}
+
+    if toml_path.exists():
+        try:
+            existing = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            existing = {}
+
+    push = existing.get("push")
+    if isinstance(push, dict) and "project" in push:
+        return [{"key": "push.project", "action": "skipped",
+                 "reason": f"already set in {PROJECT_CONFIG_FILENAME}"}]
+
+    original = toml_path.read_text(encoding="utf-8") if toml_path.exists() else ""
+    parts: list[str] = []
+    if original and not original.endswith("\n"):
+        parts.append("")
+    parts.append("")
+    parts.append("[push]")
+    parts.append(f'project = "{project_slug}"')
+    parts.append("")
+
+    with open(toml_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(parts))
+
+    return [{"key": "push.project", "action": "added"}]

--- a/src/osoji/init.py
+++ b/src/osoji/init.py
@@ -128,6 +128,72 @@ def merge_dotenv(root: Path, values: dict[str, str]) -> list[dict[str, str]]:
     return actions
 
 
+def _escape_toml_string(value: str) -> str:
+    """Escape a string for TOML double-quoted representation."""
+
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+
+def _serialize_toml(data: dict) -> str:
+    """Serialize a dict to TOML text.
+
+    Handles the flat structure used by .osoji.toml and .osoji.local.toml:
+    top-level string keys, one-level table sections, and two-level dotted
+    table sections.  All leaf values must be strings.
+    """
+
+    if not data:
+        return ""
+
+    parts: list[str] = []
+
+    # 1. Top-level scalar keys
+    for key, value in data.items():
+        if isinstance(value, str):
+            parts.append(f'{key} = "{_escape_toml_string(value)}"')
+
+    # 2. One-level table sections (values are dicts of strings)
+    for key, value in data.items():
+        if isinstance(value, dict) and all(isinstance(v, str) for v in value.values()):
+            if parts:
+                parts.append("")
+            parts.append(f"[{key}]")
+            for k, v in value.items():
+                parts.append(f'{k} = "{_escape_toml_string(v)}"')
+
+    # 3. Two-level dotted sections (values are dicts of dicts of strings)
+    for key, value in data.items():
+        if isinstance(value, dict) and any(isinstance(v, dict) for v in value.values()):
+            for subkey, subvalue in value.items():
+                if isinstance(subvalue, dict):
+                    if parts:
+                        parts.append("")
+                    parts.append(f"[{key}.{subkey}]")
+                    for k, v in subvalue.items():
+                        parts.append(f'{k} = "{_escape_toml_string(v)}"')
+
+    parts.append("")
+    return "\n".join(parts)
+
+
+def _read_toml(toml_path: Path) -> dict:
+    """Read and parse a TOML file, returning {} on missing or corrupt files."""
+
+    if not toml_path.exists():
+        return {}
+    try:
+        return tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError:
+        return {}
+
+
+def _write_toml(toml_path: Path, data: dict) -> None:
+    """Serialize *data* and write it to *toml_path*."""
+
+    with open(toml_path, "w", encoding="utf-8") as f:
+        f.write(_serialize_toml(data))
+
+
 def merge_project_toml(root: Path, *, project_slug: str | None) -> list[dict[str, str]]:
     """Ensure .osoji.toml has a [push] project entry."""
 
@@ -135,30 +201,15 @@ def merge_project_toml(root: Path, *, project_slug: str | None) -> list[dict[str
         return [{"key": "push.project", "action": "skipped", "reason": "no project slug provided"}]
 
     toml_path = root / PROJECT_CONFIG_FILENAME
-    existing: dict = {}
+    data = _read_toml(toml_path)
 
-    if toml_path.exists():
-        try:
-            existing = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except tomllib.TOMLDecodeError:
-            existing = {}
-
-    push = existing.get("push")
+    push = data.get("push")
     if isinstance(push, dict) and "project" in push:
         return [{"key": "push.project", "action": "skipped",
                  "reason": f"already set in {PROJECT_CONFIG_FILENAME}"}]
 
-    original = toml_path.read_text(encoding="utf-8") if toml_path.exists() else ""
-    parts: list[str] = []
-    if original and not original.endswith("\n"):
-        parts.append("")
-    parts.append("")
-    parts.append("[push]")
-    parts.append(f'project = "{project_slug}"')
-    parts.append("")
-
-    with open(toml_path, "a", encoding="utf-8") as f:
-        f.write("\n".join(parts))
+    data.setdefault("push", {})["project"] = project_slug
+    _write_toml(toml_path, data)
 
     return [{"key": "push.project", "action": "added"}]
 
@@ -184,18 +235,12 @@ def merge_provider_toml(
 
     filename = ".osoji.local.toml" if use_local else PROJECT_CONFIG_FILENAME
     toml_path = root / filename
-    existing: dict = {}
-
-    if toml_path.exists():
-        try:
-            existing = tomllib.loads(toml_path.read_text(encoding="utf-8"))
-        except tomllib.TOMLDecodeError:
-            existing = {}
+    data = _read_toml(toml_path)
 
     actions: list[dict[str, str]] = []
 
     # --- default_provider ---
-    if existing.get("default_provider") == provider:
+    if data.get("default_provider") == provider:
         actions.append({
             "key": "default_provider",
             "action": "skipped",
@@ -206,7 +251,7 @@ def merge_provider_toml(
 
     # --- model overrides ---
     if models:
-        existing_provider = existing.get("providers", {}).get(provider, {})
+        existing_provider = data.get("providers", {}).get(provider, {})
         for tier, model in models.items():
             if existing_provider.get(tier) == model:
                 actions.append({
@@ -220,40 +265,22 @@ def merge_provider_toml(
                     "action": "added",
                 })
 
-    # Build the TOML content to append
-    lines_to_write: list[str] = []
-
     # Only write if there's something new
     added = [a for a in actions if a["action"] == "added"]
     if not added:
         return actions
 
-    original = toml_path.read_text(encoding="utf-8") if toml_path.exists() else ""
-    if original and not original.endswith("\n"):
-        lines_to_write.append("")
-
-    # Write default_provider if it's new
+    # Merge into dict
     if any(a["key"] == "default_provider" and a["action"] == "added" for a in actions):
-        lines_to_write.append(f'default_provider = "{provider}"')
+        data["default_provider"] = provider
 
-    # Write model overrides if any
     if models:
-        model_actions_added = [
-            a for a in actions
-            if a["action"] == "added" and a["key"].startswith("providers.")
-        ]
-        if model_actions_added:
-            lines_to_write.append("")
-            lines_to_write.append(f"[providers.{provider}]")
-            for tier, model in models.items():
-                key = f"providers.{provider}.{tier}"
-                if any(a["key"] == key and a["action"] == "added" for a in actions):
-                    lines_to_write.append(f'{tier} = "{model}"')
+        for tier, model in models.items():
+            key = f"providers.{provider}.{tier}"
+            if any(a["key"] == key and a["action"] == "added" for a in actions):
+                data.setdefault("providers", {}).setdefault(provider, {})[tier] = model
 
-    lines_to_write.append("")
-
-    with open(toml_path, "a", encoding="utf-8") as f:
-        f.write("\n".join(lines_to_write))
+    _write_toml(toml_path, data)
 
     return actions
 

--- a/src/osoji/init.py
+++ b/src/osoji/init.py
@@ -6,7 +6,11 @@ import re
 import tomllib
 from pathlib import Path
 
+import click
+
 from .config import PROJECT_CONFIG_FILENAME
+from .llm.registry import get_provider_spec
+from .push import _infer_project_from_git_remote
 
 _GITIGNORE_ENTRIES: list[tuple[str, str]] = [
     (".osoji/", "intermediate results and derived data"),
@@ -137,3 +141,146 @@ def merge_project_toml(root: Path, *, project_slug: str | None) -> list[dict[str
         f.write("\n".join(parts))
 
     return [{"key": "push.project", "action": "added"}]
+
+
+def run_init(
+    *,
+    root: Path,
+    interactive: bool = True,
+    provider: str = "anthropic",
+) -> None:
+    """Orchestrate osoji project setup."""
+
+    click.echo()
+    click.echo("Osoji project setup")
+    click.echo("=" * 40)
+
+    # --- 1. Git hygiene ---
+    click.echo()
+    click.echo(click.style("1. Git hygiene", bold=True))
+
+    if interactive:
+        entries_to_add: list[tuple[str, str]] = []
+
+        for pattern, description in _GITIGNORE_ENTRIES:
+            gitignore_path = root / ".gitignore"
+            existing_lines: set[str] = set()
+            if gitignore_path.exists():
+                existing_lines = {
+                    line.strip()
+                    for line in gitignore_path.read_text(encoding="utf-8").splitlines()
+                }
+
+            if pattern in existing_lines:
+                click.echo(f"   Already in .gitignore: {pattern}")
+                continue
+
+            if click.confirm(
+                f"   Add {pattern} to .gitignore? ({description})",
+                default=True,
+            ):
+                entries_to_add.append((pattern, description))
+
+        if entries_to_add:
+            gitignore_path = root / ".gitignore"
+            original = gitignore_path.read_text(encoding="utf-8") if gitignore_path.exists() else ""
+            parts: list[str] = []
+            if original and not original.endswith("\n"):
+                parts.append("")
+            parts.append("")
+            parts.append("# Osoji")
+            for pattern, _ in entries_to_add:
+                parts.append(pattern)
+            parts.append("")
+            with open(gitignore_path, "a", encoding="utf-8") as f:
+                f.write("\n".join(parts))
+            for pattern, _ in entries_to_add:
+                click.echo(f"   {click.style('✓', fg='green')} Added {pattern}")
+    else:
+        actions = merge_gitignore(root)
+        for a in actions:
+            if a["action"] == "added":
+                click.echo(f"   {click.style('✓', fg='green')} Added {a['entry']}")
+            else:
+                click.echo(f"   Already in .gitignore: {a['entry']}")
+
+    # --- 2. Secrets (.env) ---
+    click.echo()
+    click.echo(click.style("2. Secrets (.env)", bold=True))
+
+    spec = get_provider_spec(provider)
+    api_key_env = spec.api_key_env
+
+    env_values: dict[str, str] = {}
+
+    if interactive:
+        env_path = root / ".env"
+        existing_keys: set[str] = set()
+        if env_path.exists():
+            existing_keys = _parse_env_keys(env_path.read_text(encoding="utf-8"))
+
+        click.echo(f"   LLM provider: {provider}")
+
+        if api_key_env:
+            if api_key_env in existing_keys:
+                click.echo(f"   Skipping {api_key_env} in .env (already set)")
+            elif click.confirm(f"   Set {api_key_env}?", default=True):
+                value = click.prompt(f"   {api_key_env}", default="", hide_input=True)
+                env_values[api_key_env] = value
+
+        if "OSOJI_TOKEN" in existing_keys:
+            click.echo(f"   Skipping OSOJI_TOKEN in .env (already set)")
+        elif click.confirm(f"   Set OSOJI_TOKEN? (needed for `osoji push`)", default=True):
+            value = click.prompt(f"   OSOJI_TOKEN", default="", hide_input=True)
+            env_values["OSOJI_TOKEN"] = value
+
+        if env_values:
+            env_actions = merge_dotenv(root, env_values)
+            for a in env_actions:
+                if a["action"] == "added":
+                    click.echo(f"   {click.style('✓', fg='green')} Added {a['key']} to .env")
+                else:
+                    click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
+        elif not existing_keys:
+            click.echo("   No secrets configured.")
+    else:
+        if api_key_env:
+            env_values[api_key_env] = ""
+        env_values["OSOJI_TOKEN"] = ""
+        actions = merge_dotenv(root, env_values)
+        for a in actions:
+            if a["action"] == "added":
+                click.echo(f"   {click.style('✓', fg='green')} Added {a['key']} to .env (placeholder)")
+            else:
+                click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
+
+    # --- 3. Project config (.osoji.toml) ---
+    click.echo()
+    click.echo(click.style("3. Project config (.osoji.toml)", bold=True))
+
+    inferred_slug = _infer_project_from_git_remote(root)
+
+    if interactive:
+        default_slug = inferred_slug or ""
+        project_slug = click.prompt(
+            "   Project slug (for `osoji push`)",
+            default=default_slug,
+        )
+        project_slug = project_slug.strip() or None
+    else:
+        project_slug = inferred_slug
+
+    toml_actions = merge_project_toml(root, project_slug=project_slug)
+    for a in toml_actions:
+        if a["action"] == "added":
+            click.echo(f"   {click.style('✓', fg='green')} Set [push] project = \"{project_slug}\" in .osoji.toml")
+        else:
+            click.echo(f"   Skipping {a['key']} ({a['reason']})")
+
+    # --- Done ---
+    click.echo()
+    click.echo(click.style("Done!", bold=True) + " Next steps:")
+    click.echo("  osoji audit . --dry-run    Preview what osoji will analyze")
+    click.echo("  osoji audit .              Run a full audit")
+    click.echo("  osoji config show          See resolved configuration")
+    click.echo()

--- a/src/osoji/init.py
+++ b/src/osoji/init.py
@@ -8,14 +8,23 @@ from pathlib import Path
 
 import click
 
-from .config import PROJECT_CONFIG_FILENAME
-from .llm.registry import get_provider_spec
+from .config import BUILTIN_PROVIDER_MODELS, PROJECT_CONFIG_FILENAME
+from .llm.registry import get_provider_spec, provider_names
 from .push import _infer_project_from_git_remote
 
 _GITIGNORE_ENTRIES: list[tuple[str, str]] = [
     (".osoji/", "intermediate results and derived data"),
     (".osoji.local.toml", "local config overrides"),
     (".env", "secrets file"),
+]
+
+# Display order and one-liner descriptions for provider selection.
+_PROVIDER_MENU: list[tuple[str, str]] = [
+    ("anthropic", "Claude models, built-in defaults"),
+    ("openai", "GPT models, built-in defaults"),
+    ("google", "Gemini models, built-in defaults"),
+    ("openrouter", "Multi-provider gateway, built-in defaults"),
+    ("claude-code", "Uses your Claude Code subscription (no API key needed)"),
 ]
 
 
@@ -154,6 +163,169 @@ def merge_project_toml(root: Path, *, project_slug: str | None) -> list[dict[str
     return [{"key": "push.project", "action": "added"}]
 
 
+def merge_provider_toml(
+    root: Path,
+    *,
+    provider: str,
+    models: dict[str, str] | None = None,
+    use_local: bool = False,
+) -> list[dict[str, str]]:
+    """Write provider config to a toml file.
+
+    Writes ``default_provider`` and optionally ``[providers.<name>]`` model
+    overrides.  *models* should only contain values that differ from the
+    built-in defaults (callers should filter before calling).
+
+    Parameters
+    ----------
+    use_local:
+        If True, write to ``.osoji.local.toml`` instead of ``.osoji.toml``.
+    """
+
+    filename = ".osoji.local.toml" if use_local else PROJECT_CONFIG_FILENAME
+    toml_path = root / filename
+    existing: dict = {}
+
+    if toml_path.exists():
+        try:
+            existing = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError:
+            existing = {}
+
+    actions: list[dict[str, str]] = []
+
+    # --- default_provider ---
+    if existing.get("default_provider") == provider:
+        actions.append({
+            "key": "default_provider",
+            "action": "skipped",
+            "reason": f"already set in {filename}",
+        })
+    else:
+        actions.append({"key": "default_provider", "action": "added"})
+
+    # --- model overrides ---
+    if models:
+        existing_provider = existing.get("providers", {}).get(provider, {})
+        for tier, model in models.items():
+            if existing_provider.get(tier) == model:
+                actions.append({
+                    "key": f"providers.{provider}.{tier}",
+                    "action": "skipped",
+                    "reason": f"already set in {filename}",
+                })
+            else:
+                actions.append({
+                    "key": f"providers.{provider}.{tier}",
+                    "action": "added",
+                })
+
+    # Build the TOML content to append
+    lines_to_write: list[str] = []
+
+    # Only write if there's something new
+    added = [a for a in actions if a["action"] == "added"]
+    if not added:
+        return actions
+
+    original = toml_path.read_text(encoding="utf-8") if toml_path.exists() else ""
+    if original and not original.endswith("\n"):
+        lines_to_write.append("")
+
+    # Write default_provider if it's new
+    if any(a["key"] == "default_provider" and a["action"] == "added" for a in actions):
+        lines_to_write.append(f'default_provider = "{provider}"')
+
+    # Write model overrides if any
+    if models:
+        model_actions_added = [
+            a for a in actions
+            if a["action"] == "added" and a["key"].startswith("providers.")
+        ]
+        if model_actions_added:
+            lines_to_write.append("")
+            lines_to_write.append(f"[providers.{provider}]")
+            for tier, model in models.items():
+                key = f"providers.{provider}.{tier}"
+                if any(a["key"] == key and a["action"] == "added" for a in actions):
+                    lines_to_write.append(f'{tier} = "{model}"')
+
+    lines_to_write.append("")
+
+    with open(toml_path, "a", encoding="utf-8") as f:
+        f.write("\n".join(lines_to_write))
+
+    return actions
+
+
+def _prompt_provider_selection() -> str:
+    """Show numbered provider list and return the chosen provider name."""
+
+    click.echo("   Choose your LLM provider:")
+    click.echo()
+    for i, (name, description) in enumerate(_PROVIDER_MENU, 1):
+        spec = get_provider_spec(name)
+        click.echo(f"     {i}. {spec.display_name:<18} {description}")
+    click.echo()
+
+    choice = click.prompt(
+        "   Provider",
+        type=click.IntRange(1, len(_PROVIDER_MENU)),
+        default=1,
+    )
+    return _PROVIDER_MENU[choice - 1][0]
+
+
+def _prompt_model_defaults(provider: str) -> dict[str, str] | None:
+    """Show model defaults and let the user accept or override.
+
+    Returns a dict of overridden tiers (only values that differ from
+    built-in defaults), or None if defaults were accepted.
+    """
+
+    defaults = BUILTIN_PROVIDER_MODELS.get(provider)
+    if not defaults:
+        return None
+
+    click.echo()
+    spec = get_provider_spec(provider)
+    click.echo(f"   Model defaults for {spec.display_name}:")
+    click.echo(f"     small:  {defaults['small']}")
+    click.echo(f"     medium: {defaults['medium']}")
+    click.echo(f"     large:  {defaults['large']}")
+
+    if click.confirm("   Accept defaults?", default=True):
+        return None
+
+    overrides: dict[str, str] = {}
+    for tier in ("small", "medium", "large"):
+        value = click.prompt(f"   {tier} model", default=defaults[tier])
+        value = value.strip()
+        if value != defaults[tier]:
+            overrides[tier] = value
+
+    return overrides or None
+
+
+def _prompt_config_target() -> bool:
+    """Ask whether to save to shared or personal config.
+
+    Returns True for .osoji.local.toml, False for .osoji.toml.
+    """
+
+    click.echo()
+    click.echo("   Save provider config to:")
+    click.echo("     1. .osoji.toml        Shared with team, committed to git (Recommended)")
+    click.echo("     2. .osoji.local.toml  Personal, gitignored")
+    click.echo()
+    choice = click.prompt(
+        "   Config target",
+        type=click.IntRange(1, 2),
+        default=1,
+    )
+    return choice == 2
+
+
 def run_init(
     *,
     root: Path,
@@ -215,13 +387,62 @@ def run_init(
             else:
                 click.echo(f"   Already in .gitignore: {a['entry']}")
 
-    # --- 2. Secrets (.env) ---
+    # --- 2. Provider setup ---
     click.echo()
-    click.echo(click.style("2. Secrets (.env)", bold=True))
+    click.echo(click.style("2. Provider setup", bold=True))
 
-    spec = get_provider_spec(provider)
+    model_overrides: dict[str, str] | None = None
+    use_local_config = False
+
+    if interactive:
+        # Provider selection (--provider flag pre-selects)
+        provider_from_flag = provider != "anthropic"
+        if provider_from_flag:
+            spec = get_provider_spec(provider)
+            click.echo(f"   Provider: {spec.display_name} (from --provider flag)")
+        else:
+            provider = _prompt_provider_selection()
+            spec = get_provider_spec(provider)
+            click.echo(f"   Selected: {spec.display_name}")
+
+        # Model defaults (skip for claude-code — it manages models internally)
+        if provider != "claude-code":
+            model_overrides = _prompt_model_defaults(provider)
+        else:
+            click.echo("   Claude Code manages model selection internally.")
+
+        # Config target
+        use_local_config = _prompt_config_target()
+    else:
+        spec = get_provider_spec(provider)
+        click.echo(f"   Provider: {spec.display_name} (built-in defaults)")
+
+    # Write provider config
+    provider_actions = merge_provider_toml(
+        root,
+        provider=provider,
+        models=model_overrides,
+        use_local=use_local_config,
+    )
+    target_file = ".osoji.local.toml" if use_local_config else PROJECT_CONFIG_FILENAME
+    for a in provider_actions:
+        if a["action"] == "added":
+            click.echo(f"   {click.style('ok', fg='green')} Set {a['key']} in {target_file}")
+        else:
+            click.echo(f"   Skipping {a['key']} ({a['reason']})")
+
+    # Guidance
+    click.echo()
+    click.echo("   Tip: To switch providers later, set default_provider in your config file:")
+    click.echo(f'     default_provider = "{provider}"')
+    click.echo("   Or set OSOJI_PROVIDER and OSOJI_MODEL environment variables.")
+    click.echo("   Run `osoji config show` to see your current configuration.")
+
+    # --- 3. Secrets (.env) ---
+    click.echo()
+    click.echo(click.style("3. Secrets (.env)", bold=True))
+
     api_key_env = spec.api_key_env
-
     env_values: dict[str, str] = {}
 
     if interactive:
@@ -230,19 +451,23 @@ def run_init(
         if env_path.exists():
             existing_keys = _parse_env_keys(env_path.read_text(encoding="utf-8"))
 
-        click.echo(f"   LLM provider: {provider}")
-
-        if api_key_env:
+        if provider == "claude-code":
+            click.echo("   Claude Code uses your existing subscription. No API key needed.")
+        elif api_key_env:
             if api_key_env in existing_keys:
                 click.echo(f"   Skipping {api_key_env} in .env (already set)")
             elif click.confirm(f"   Set {api_key_env}?", default=True):
                 value = click.prompt(f"   {api_key_env}", default="", hide_input=True)
                 env_values[api_key_env] = value
+            else:
+                click.echo(f"   Skipped. Add your API key later in .env:")
+                click.echo(f"     {api_key_env}=<your-key>")
+                click.echo(f"   Or set it as an environment variable.")
 
         if "OSOJI_TOKEN" in existing_keys:
             click.echo(f"   Skipping OSOJI_TOKEN in .env (already set)")
-        elif click.confirm(f"   Set OSOJI_TOKEN? (needed for `osoji push`)", default=True):
-            value = click.prompt(f"   OSOJI_TOKEN", default="", hide_input=True)
+        elif click.confirm("   Set OSOJI_TOKEN? (needed for `osoji push`)", default=True):
+            value = click.prompt("   OSOJI_TOKEN", default="", hide_input=True)
             env_values["OSOJI_TOKEN"] = value
 
         if env_values:
@@ -252,7 +477,7 @@ def run_init(
                     click.echo(f"   {click.style('ok', fg='green')} Added {a['key']} to .env")
                 else:
                     click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
-        elif not existing_keys:
+        elif not existing_keys and provider != "claude-code":
             click.echo("   No secrets configured.")
     else:
         if api_key_env:
@@ -265,9 +490,9 @@ def run_init(
             else:
                 click.echo(f"   Skipping {a['key']} in .env ({a['reason']})")
 
-    # --- 3. Project config (.osoji.toml) ---
+    # --- 4. Project config (.osoji.toml) ---
     click.echo()
-    click.echo(click.style("3. Project config (.osoji.toml)", bold=True))
+    click.echo(click.style("4. Project config (.osoji.toml)", bold=True))
 
     inferred_slug = _infer_project_from_git_remote(root)
 

--- a/src/osoji/llm/registry.py
+++ b/src/osoji/llm/registry.py
@@ -42,7 +42,7 @@ _PROVIDER_SPECS: dict[str, ProviderSpec] = {
         litellm_prefix="gemini",
         api_key_env="GEMINI_API_KEY",
         rate_limit_name="google",
-        requires_explicit_model=True,
+        requires_explicit_model=False,
     ),
     "openrouter": ProviderSpec(
         name="openrouter",
@@ -50,7 +50,7 @@ _PROVIDER_SPECS: dict[str, ProviderSpec] = {
         litellm_prefix="openrouter",
         api_key_env="OPENROUTER_API_KEY",
         rate_limit_name="openrouter",
-        requires_explicit_model=True,
+        requires_explicit_model=False,
     ),
     "claude-code": ProviderSpec(
         name="claude-code",

--- a/src/osoji/push.py
+++ b/src/osoji/push.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from urllib.request import Request, urlopen
 
 import click
 import tomllib
+from dotenv import dotenv_values
 
 from . import __version__
 from .config import LOCAL_CONFIG_FILENAME, PROJECT_CONFIG_FILENAME, get_global_config_path
@@ -28,6 +30,7 @@ class PushConfig:
     endpoint: str
     token: str
     project_slug: str
+    token_source: str = ""  # provenance label for diagnostics
 
 
 @dataclass(frozen=True)
@@ -69,14 +72,21 @@ def _load_push_section(path: Path) -> dict[str, str]:
     return {k: str(v) for k, v in push.items() if isinstance(v, str)}
 
 
-def _merge_push_config(root: Path) -> dict[str, str]:
-    """Merge [push] config from global -> .osoji.toml -> .osoji.local.toml."""
+def _merge_push_config(root: Path) -> tuple[dict[str, str], dict[str, str]]:
+    """Merge [push] config and track which file each key came from."""
 
     merged: dict[str, str] = {}
-    merged.update(_load_push_section(get_global_config_path()))
-    merged.update(_load_push_section(root / PROJECT_CONFIG_FILENAME))
-    merged.update(_load_push_section(root / LOCAL_CONFIG_FILENAME))
-    return merged
+    sources: dict[str, str] = {}
+    for path, label in [
+        (get_global_config_path(), "global config"),
+        (root / PROJECT_CONFIG_FILENAME, ".osoji.toml"),
+        (root / LOCAL_CONFIG_FILENAME, ".osoji.local.toml"),
+    ]:
+        section = _load_push_section(path)
+        for k, v in section.items():
+            merged[k] = v
+            sources[k] = label
+    return merged, sources
 
 
 def _infer_project_from_git_remote(root: Path) -> str | None:
@@ -111,6 +121,16 @@ def _infer_project_from_git_remote(root: Path) -> str | None:
     return None
 
 
+def _classify_env_source(var_name: str) -> str:
+    """Return '.env file' if the env var value matches the .env file, else 'env var'."""
+
+    env_file = dotenv_values()
+    env_val = os.environ.get(var_name)
+    if env_val and var_name in env_file and env_file[var_name] == env_val:
+        return ".env file"
+    return f"{var_name} env var"
+
+
 def resolve_push_config(
     *,
     endpoint: str | None,
@@ -120,22 +140,38 @@ def resolve_push_config(
 ) -> PushConfig:
     """Resolve push config: CLI arg -> env var -> TOML config -> git remote -> error."""
 
-    import os
+    merged, toml_sources = _merge_push_config(root_path)
 
-    merged = _merge_push_config(root_path)
-
-    resolved_endpoint = endpoint or os.environ.get("OSOJI_ENDPOINT") or merged.get("endpoint")
-    if not resolved_endpoint:
+    # --- endpoint ---
+    if endpoint:
+        resolved_endpoint = endpoint
+    elif os.environ.get("OSOJI_ENDPOINT"):
+        resolved_endpoint = os.environ["OSOJI_ENDPOINT"]
+    elif merged.get("endpoint"):
+        resolved_endpoint = merged["endpoint"]
+    else:
         raise click.ClickException(
-            "OSOJI_ENDPOINT is not set. Pass --endpoint or set the OSOJI_ENDPOINT environment variable."
+            "OSOJI_ENDPOINT is not set. Set [push] endpoint in .osoji.toml, "
+            "pass --endpoint, or set the OSOJI_ENDPOINT environment variable."
         )
 
-    resolved_token = token or os.environ.get("OSOJI_TOKEN") or merged.get("token")
-    if not resolved_token:
+    # --- token ---
+    if token:
+        resolved_token = token
+        token_source = "--token flag"
+    elif os.environ.get("OSOJI_TOKEN"):
+        resolved_token = os.environ["OSOJI_TOKEN"]
+        token_source = _classify_env_source("OSOJI_TOKEN")
+    elif merged.get("token"):
+        resolved_token = merged["token"]
+        token_source = toml_sources["token"]
+    else:
         raise click.ClickException(
-            "OSOJI_TOKEN is not set. Pass --token or set the OSOJI_TOKEN environment variable."
+            "OSOJI_TOKEN is not set. Add OSOJI_TOKEN=<your-token> to .env, "
+            "or pass --token, or set the OSOJI_TOKEN environment variable."
         )
 
+    # --- project ---
     resolved_project = project or merged.get("project")
     if not resolved_project:
         resolved_project = _infer_project_from_git_remote(root_path)
@@ -153,6 +189,7 @@ def resolve_push_config(
         endpoint=resolved_endpoint,
         token=resolved_token,
         project_slug=resolved_project,
+        token_source=token_source,
     )
 
 
@@ -371,6 +408,7 @@ def run_push(
     git_context = gather_git_context(git_root)
 
     if not quiet:
+        click.echo(f"Token loaded from {push_config.token_source}", err=True)
         click.echo(
             f"Pushing {push_config.project_slug} "
             f"@ {git_context.commit[:8]} to {push_config.endpoint}",
@@ -384,6 +422,11 @@ def run_push(
     result = _post_envelope(push_config.endpoint, push_config.token, envelope)
 
     if not result.success:
+        if result.status_code == 401:
+            raise click.ClickException(
+                f"Authentication failed. Check the OSOJI_TOKEN value "
+                f"(loaded from {push_config.token_source})."
+            )
         raise click.ClickException(result.error_message or "Push failed.")
 
     return result

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,7 +3,13 @@
 from pathlib import Path
 from unittest.mock import patch, call
 
-from osoji.init import merge_dotenv, merge_gitignore, merge_project_toml, run_init
+from osoji.init import (
+    merge_dotenv,
+    merge_gitignore,
+    merge_project_toml,
+    merge_provider_toml,
+    run_init,
+)
 
 
 class TestMergeGitignore:
@@ -127,6 +133,52 @@ class TestMergeProjectToml:
         assert actions[0]["action"] == "skipped"
 
 
+class TestMergeProviderToml:
+    def test_writes_provider_to_project_toml(self, tmp_path):
+        actions = merge_provider_toml(tmp_path, provider="anthropic")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "anthropic"' in content
+        added = [a for a in actions if a["action"] == "added"]
+        assert len(added) == 1
+        assert added[0]["key"] == "default_provider"
+
+    def test_writes_provider_to_local_toml(self, tmp_path):
+        actions = merge_provider_toml(tmp_path, provider="openai", use_local=True)
+        content = (tmp_path / ".osoji.local.toml").read_text()
+        assert 'default_provider = "openai"' in content
+        assert not (tmp_path / ".osoji.toml").exists()
+
+    def test_writes_model_overrides(self, tmp_path):
+        models = {"small": "custom-small", "large": "custom-large"}
+        actions = merge_provider_toml(tmp_path, provider="openai", models=models)
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "openai"' in content
+        assert "[providers.openai]" in content
+        assert 'small = "custom-small"' in content
+        assert 'large = "custom-large"' in content
+
+    def test_skips_existing_provider(self, tmp_path):
+        (tmp_path / ".osoji.toml").write_text('default_provider = "anthropic"\n')
+        actions = merge_provider_toml(tmp_path, provider="anthropic")
+        skipped = [a for a in actions if a["action"] == "skipped"]
+        assert len(skipped) == 1
+        assert skipped[0]["key"] == "default_provider"
+
+    def test_no_models_means_no_providers_section(self, tmp_path):
+        actions = merge_provider_toml(tmp_path, provider="google")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "google"' in content
+        assert "[providers." not in content
+
+    def test_appends_to_existing_toml(self, tmp_path):
+        (tmp_path / ".osoji.toml").write_text('[push]\nproject = "myproject"\n')
+        actions = merge_provider_toml(tmp_path, provider="openai")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert '[push]' in content
+        assert 'project = "myproject"' in content
+        assert 'default_provider = "openai"' in content
+
+
 class TestRunInit:
     def test_non_interactive_creates_all_files(self, tmp_path):
         """Non-interactive mode creates files with commented-out placeholders."""
@@ -135,6 +187,9 @@ class TestRunInit:
         assert (tmp_path / ".env").exists()
         env_content = (tmp_path / ".env").read_text()
         assert "# ANTHROPIC_API_KEY=" in env_content
+        # Provider config is written to .osoji.toml
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "anthropic"' in toml_content
 
     def test_non_interactive_respects_existing_env(self, tmp_path):
         (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-existing\n")
@@ -143,8 +198,11 @@ class TestRunInit:
         assert "sk-existing" in env_content
 
     @patch("click.confirm", return_value=True)
-    @patch("click.prompt", side_effect=["sk-test-key", "", "myproject"])
+    @patch("click.prompt")
     def test_interactive_prompts_for_values(self, mock_prompt, mock_confirm, tmp_path):
+        # Prompts: provider selection (1), model accept (Y from confirm),
+        # config target (1), API key, OSOJI_TOKEN, project slug
+        mock_prompt.side_effect = [1, 1, "sk-test-key", "", "myproject"]
         run_init(root=tmp_path, interactive=True, provider="anthropic")
         env_content = (tmp_path / ".env").read_text()
         assert "ANTHROPIC_API_KEY=sk-test-key" in env_content
@@ -154,16 +212,128 @@ class TestRunInit:
     @patch("click.prompt", return_value="")
     @patch("click.confirm", return_value=False)
     def test_interactive_skips_when_declined(self, mock_confirm, mock_prompt, tmp_path):
-        """When user declines all prompts, no files are created."""
+        """When user declines all prompts, minimal files are created."""
+        # confirm returns False for everything: gitignore (3x), model accept, API key, OSOJI_TOKEN
+        # prompt calls: provider (1), small/medium/large models (defaults), config target (1), project slug
+        from osoji.config import BUILTIN_PROVIDER_MODELS
+        defaults = BUILTIN_PROVIDER_MODELS["anthropic"]
+        mock_prompt.side_effect = [
+            1,                    # provider selection
+            defaults["small"],    # small model (confirm=False → override prompts)
+            defaults["medium"],   # medium model
+            defaults["large"],    # large model
+            1,                    # config target
+            "",                   # project slug
+        ]
         run_init(root=tmp_path, interactive=True, provider="anthropic")
         assert not (tmp_path / ".gitignore").exists()
-        assert not (tmp_path / ".env").exists()
 
     def test_non_interactive_openai_provider(self, tmp_path):
         run_init(root=tmp_path, interactive=False, provider="openai")
         env_content = (tmp_path / ".env").read_text()
         assert "# OPENAI_API_KEY=" in env_content
         assert "ANTHROPIC_API_KEY" not in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "openai"' in toml_content
+
+    def test_non_interactive_claude_code_no_api_key(self, tmp_path):
+        """claude-code provider has no API key env var — only OSOJI_TOKEN placeholder."""
+        run_init(root=tmp_path, interactive=False, provider="claude-code")
+        env_content = (tmp_path / ".env").read_text()
+        assert "ANTHROPIC_API_KEY" not in env_content
+        assert "# OSOJI_TOKEN=" in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "claude-code"' in toml_content
+
+    def test_non_interactive_google_provider(self, tmp_path):
+        run_init(root=tmp_path, interactive=False, provider="google")
+        env_content = (tmp_path / ".env").read_text()
+        assert "# GEMINI_API_KEY=" in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "google"' in toml_content
+
+    def test_non_interactive_openrouter_provider(self, tmp_path):
+        run_init(root=tmp_path, interactive=False, provider="openrouter")
+        env_content = (tmp_path / ".env").read_text()
+        assert "# OPENROUTER_API_KEY=" in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "openrouter"' in toml_content
+
+    @patch("click.confirm", return_value=True)
+    @patch("click.prompt")
+    def test_interactive_provider_flag_skips_selection(self, mock_prompt, mock_confirm, tmp_path):
+        """When --provider is explicitly set (not default), skip selection prompt."""
+        # With provider="openai" (non-default), prompts are: model accept (confirm),
+        # config target, API key, OSOJI_TOKEN, project slug
+        mock_prompt.side_effect = [1, "sk-openai", "", "myproject"]
+        run_init(root=tmp_path, interactive=True, provider="openai")
+        env_content = (tmp_path / ".env").read_text()
+        assert "OPENAI_API_KEY=sk-openai" in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "openai"' in toml_content
+
+    @patch("click.confirm")
+    @patch("click.prompt")
+    def test_interactive_model_override(self, mock_prompt, mock_confirm, tmp_path):
+        """User can override individual model tiers."""
+        # Sequence: provider (1=anthropic), model accept (N from confirm),
+        # small model, medium model, large model, config target (1),
+        # set API key? (Y), API key value, set OSOJI_TOKEN? (Y), token, project slug
+        mock_confirm.side_effect = [
+            True, True, True,  # gitignore entries
+            False,             # decline model defaults
+            True,              # set API key
+            True,              # set OSOJI_TOKEN
+        ]
+        mock_prompt.side_effect = [
+            1,                               # provider selection
+            "my-small", "my-medium", "my-large",  # model overrides
+            1,                               # config target
+            "sk-key",                        # API key
+            "",                              # OSOJI_TOKEN
+            "myproject",                     # project slug
+        ]
+        run_init(root=tmp_path, interactive=True, provider="anthropic")
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "anthropic"' in toml_content
+        assert "[providers.anthropic]" in toml_content
+        assert 'small = "my-small"' in toml_content
+        assert 'medium = "my-medium"' in toml_content
+        assert 'large = "my-large"' in toml_content
+
+    @patch("click.confirm", return_value=True)
+    @patch("click.prompt")
+    def test_interactive_local_config_target(self, mock_prompt, mock_confirm, tmp_path):
+        """User can save provider config to .osoji.local.toml."""
+        # provider (1), config target (2=local), API key, OSOJI_TOKEN, project slug
+        mock_prompt.side_effect = [1, 2, "sk-key", "", "myproject"]
+        run_init(root=tmp_path, interactive=True, provider="anthropic")
+        assert (tmp_path / ".osoji.local.toml").exists()
+        local_content = (tmp_path / ".osoji.local.toml").read_text()
+        assert 'default_provider = "anthropic"' in local_content
+
+    @patch("click.confirm", return_value=True)
+    @patch("click.prompt")
+    def test_interactive_claude_code_skips_api_key(self, mock_prompt, mock_confirm, tmp_path):
+        """claude-code provider skips API key prompt and model defaults."""
+        # provider (5=claude-code), config target (1), OSOJI_TOKEN, project slug
+        mock_prompt.side_effect = [5, 1, "", "myproject"]
+        run_init(root=tmp_path, interactive=True, provider="anthropic")
+        # No API key in .env (only OSOJI_TOKEN placeholder if declined)
+        if (tmp_path / ".env").exists():
+            env_content = (tmp_path / ".env").read_text()
+            assert "ANTHROPIC_API_KEY" not in env_content
+            assert "OPENAI_API_KEY" not in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "claude-code"' in toml_content
+
+    def test_non_interactive_idempotent(self, tmp_path):
+        """Running init twice is idempotent — skips existing entries."""
+        run_init(root=tmp_path, interactive=False, provider="anthropic")
+        run_init(root=tmp_path, interactive=False, provider="anthropic")
+        env_content = (tmp_path / ".env").read_text()
+        assert env_content.count("ANTHROPIC_API_KEY") == 1
+        assert env_content.count("OSOJI_TOKEN") == 1
 
 
 class TestInitCLI:
@@ -175,8 +345,20 @@ class TestInitCLI:
         result = runner.invoke(main, ["init", str(tmp_path), "--non-interactive"])
         assert result.exit_code == 0
         assert "Osoji project setup" in result.output
+        assert "Provider setup" in result.output
         assert (tmp_path / ".gitignore").exists()
         assert (tmp_path / ".env").exists()
+
+    def test_init_non_interactive_with_provider(self, tmp_path):
+        from click.testing import CliRunner
+        from osoji.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["init", str(tmp_path), "--non-interactive", "--provider", "google"])
+        assert result.exit_code == 0
+        assert "Google Gemini" in result.output
+        env_content = (tmp_path / ".env").read_text()
+        assert "GEMINI_API_KEY" in env_content
 
     def test_init_help(self):
         from click.testing import CliRunner

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -153,3 +153,26 @@ class TestRunInit:
         env_content = (tmp_path / ".env").read_text()
         assert "# OPENAI_API_KEY=" in env_content
         assert "ANTHROPIC_API_KEY" not in env_content
+
+
+class TestInitCLI:
+    def test_init_non_interactive_creates_files(self, tmp_path):
+        from click.testing import CliRunner
+        from osoji.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["init", str(tmp_path), "--non-interactive"])
+        assert result.exit_code == 0
+        assert "Osoji project setup" in result.output
+        assert (tmp_path / ".gitignore").exists()
+        assert (tmp_path / ".env").exists()
+
+    def test_init_help(self):
+        from click.testing import CliRunner
+        from osoji.cli import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["init", "--help"])
+        assert result.exit_code == 0
+        assert "--non-interactive" in result.output
+        assert "--provider" in result.output

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,37 @@
+"""Tests for osoji init module."""
+
+from pathlib import Path
+
+from osoji.init import merge_gitignore
+
+
+class TestMergeGitignore:
+    def test_creates_gitignore_when_missing(self, tmp_path):
+        actions = merge_gitignore(tmp_path)
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".osoji/" in content
+        assert ".osoji.local.toml" in content
+        assert ".env" in content
+        assert len(actions) == 3
+        assert all(a["action"] == "added" for a in actions)
+
+    def test_skips_existing_entries(self, tmp_path):
+        (tmp_path / ".gitignore").write_text(".osoji/\n.env\n")
+        actions = merge_gitignore(tmp_path)
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".osoji.local.toml" in content
+        added = [a for a in actions if a["action"] == "added"]
+        skipped = [a for a in actions if a["action"] == "skipped"]
+        assert len(added) == 1
+        assert len(skipped) == 2
+
+    def test_all_present_no_changes(self, tmp_path):
+        (tmp_path / ".gitignore").write_text(".osoji/\n.osoji.local.toml\n.env\n")
+        actions = merge_gitignore(tmp_path)
+        assert all(a["action"] == "skipped" for a in actions)
+
+    def test_appends_with_separator(self, tmp_path):
+        (tmp_path / ".gitignore").write_text("node_modules/\n*.pyc\n")
+        actions = merge_gitignore(tmp_path)
+        content = (tmp_path / ".gitignore").read_text()
+        assert "\n# Osoji\n" in content

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,58 @@
 """Tests for osoji init module."""
 
+import tomllib
 from pathlib import Path
 from unittest.mock import patch, call
 
 from osoji.init import (
+    _serialize_toml,
     merge_dotenv,
     merge_gitignore,
     merge_project_toml,
     merge_provider_toml,
     run_init,
 )
+
+
+class TestSerializeToml:
+    def test_empty_dict(self):
+        assert _serialize_toml({}) == ""
+
+    def test_top_level_only(self):
+        result = _serialize_toml({"default_provider": "anthropic"})
+        parsed = tomllib.loads(result)
+        assert parsed == {"default_provider": "anthropic"}
+
+    def test_with_section(self):
+        data = {"default_provider": "anthropic", "push": {"project": "osoji"}}
+        result = _serialize_toml(data)
+        parsed = tomllib.loads(result)
+        assert parsed == data
+        # default_provider must appear before [push]
+        assert result.index("default_provider") < result.index("[push]")
+
+    def test_with_nested_section(self):
+        data = {"providers": {"openai": {"small": "gpt-5-mini", "large": "gpt-5.4"}}}
+        result = _serialize_toml(data)
+        parsed = tomllib.loads(result)
+        assert parsed == data
+        assert "[providers.openai]" in result
+
+    def test_full_roundtrip(self):
+        data = {
+            "default_provider": "openai",
+            "push": {"endpoint": "https://api.osojicode.ai", "project": "osoji"},
+            "providers": {"openai": {"small": "gpt-5-mini", "large": "gpt-5.4"}},
+        }
+        result = _serialize_toml(data)
+        parsed = tomllib.loads(result)
+        assert parsed == data
+
+    def test_string_escaping(self):
+        data = {"key": 'value with "quotes" and \\backslash'}
+        result = _serialize_toml(data)
+        parsed = tomllib.loads(result)
+        assert parsed == data
 
 
 class TestMergeGitignore:
@@ -132,6 +175,17 @@ class TestMergeProjectToml:
         assert not (tmp_path / ".osoji.toml").exists()
         assert actions[0]["action"] == "skipped"
 
+    def test_project_with_preexisting_push_section(self, tmp_path):
+        """Adding project to existing [push] must not create duplicate section."""
+        (tmp_path / ".osoji.toml").write_text('[push]\nendpoint = "https://api.osojicode.ai"\n')
+        actions = merge_project_toml(tmp_path, project_slug="osoji")
+        content = (tmp_path / ".osoji.toml").read_text()
+        parsed = tomllib.loads(content)  # must not raise
+        assert parsed["push"]["project"] == "osoji"
+        assert parsed["push"]["endpoint"] == "https://api.osojicode.ai"
+        assert content.count("[push]") == 1
+        assert actions[0]["action"] == "added"
+
 
 class TestMergeProviderToml:
     def test_writes_provider_to_project_toml(self, tmp_path):
@@ -170,13 +224,37 @@ class TestMergeProviderToml:
         assert 'default_provider = "google"' in content
         assert "[providers." not in content
 
-    def test_appends_to_existing_toml(self, tmp_path):
+    def test_merges_into_existing_toml(self, tmp_path):
         (tmp_path / ".osoji.toml").write_text('[push]\nproject = "myproject"\n')
         actions = merge_provider_toml(tmp_path, provider="openai")
         content = (tmp_path / ".osoji.toml").read_text()
         assert '[push]' in content
         assert 'project = "myproject"' in content
         assert 'default_provider = "openai"' in content
+
+    def test_provider_with_preexisting_push_section(self, tmp_path):
+        """default_provider must be top-level, not inside [push]."""
+        (tmp_path / ".osoji.toml").write_text('[push]\nendpoint = "https://api.osojicode.ai"\n')
+        merge_provider_toml(tmp_path, provider="anthropic")
+        content = (tmp_path / ".osoji.toml").read_text()
+        parsed = tomllib.loads(content)
+        # default_provider must be top-level, NOT inside push
+        assert parsed.get("default_provider") == "anthropic"
+        assert "default_provider" not in parsed.get("push", {})
+        # endpoint must be preserved
+        assert parsed["push"]["endpoint"] == "https://api.osojicode.ai"
+
+    def test_provider_then_project_no_corruption(self, tmp_path):
+        """Calling both merge functions in sequence produces valid TOML."""
+        (tmp_path / ".osoji.toml").write_text('[push]\nendpoint = "https://api.osojicode.ai"\n')
+        merge_provider_toml(tmp_path, provider="anthropic")
+        merge_project_toml(tmp_path, project_slug="osoji")
+        content = (tmp_path / ".osoji.toml").read_text()
+        parsed = tomllib.loads(content)  # must not raise
+        assert parsed["default_provider"] == "anthropic"
+        assert parsed["push"]["endpoint"] == "https://api.osojicode.ai"
+        assert parsed["push"]["project"] == "osoji"
+        assert content.count("[push]") == 1
 
 
 class TestRunInit:
@@ -327,13 +405,32 @@ class TestRunInit:
         toml_content = (tmp_path / ".osoji.toml").read_text()
         assert 'default_provider = "claude-code"' in toml_content
 
-    def test_non_interactive_idempotent(self, tmp_path):
+    @patch("osoji.init._infer_project_from_git_remote", return_value="myproject")
+    def test_non_interactive_idempotent(self, _mock_infer, tmp_path):
         """Running init twice is idempotent — skips existing entries."""
         run_init(root=tmp_path, interactive=False, provider="anthropic")
         run_init(root=tmp_path, interactive=False, provider="anthropic")
         env_content = (tmp_path / ".env").read_text()
         assert env_content.count("ANTHROPIC_API_KEY") == 1
         assert env_content.count("OSOJI_TOKEN") == 1
+        # TOML must be valid with no duplicate sections
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        parsed = tomllib.loads(toml_content)
+        assert parsed.get("default_provider") == "anthropic"
+        assert parsed["push"]["project"] == "myproject"
+        assert toml_content.count("[push]") == 1
+
+    @patch("osoji.init._infer_project_from_git_remote", return_value="osoji")
+    def test_non_interactive_with_preexisting_push(self, _mock_infer, tmp_path):
+        """Init on a repo with existing [push] endpoint preserves it and produces valid TOML."""
+        (tmp_path / ".osoji.toml").write_text('[push]\nendpoint = "https://api.osojicode.ai"\n')
+        run_init(root=tmp_path, interactive=False, provider="anthropic")
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        parsed = tomllib.loads(toml_content)
+        assert parsed["default_provider"] == "anthropic"
+        assert parsed["push"]["endpoint"] == "https://api.osojicode.ai"
+        assert parsed["push"]["project"] == "osoji"
+        assert toml_content.count("[push]") == 1
 
 
 class TestInitCLI:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -83,6 +83,17 @@ class TestMergeDotenv:
         added = [a for a in actions if a["action"] == "added"]
         assert len(added) == 1
 
+    def test_skips_commented_placeholder_when_empty(self, tmp_path):
+        """Writing an empty value when a commented-out placeholder exists should skip."""
+        (tmp_path / ".env").write_text("# OSOJI_TOKEN=\n")
+        values = {"OSOJI_TOKEN": ""}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        # Should NOT add a second placeholder
+        assert content.count("OSOJI_TOKEN") == 1
+        skipped = [a for a in actions if a["action"] == "skipped"]
+        assert len(skipped) == 1
+
 
 class TestMergeProjectToml:
     def test_creates_toml_when_missing(self, tmp_path):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from osoji.init import merge_gitignore
+from osoji.init import merge_dotenv, merge_gitignore, merge_project_toml
 
 
 class TestMergeGitignore:
@@ -35,3 +35,49 @@ class TestMergeGitignore:
         actions = merge_gitignore(tmp_path)
         content = (tmp_path / ".gitignore").read_text()
         assert "\n# Osoji\n" in content
+
+
+class TestMergeDotenv:
+    def test_creates_env_when_missing(self, tmp_path):
+        values = {"ANTHROPIC_API_KEY": "sk-test", "OSOJI_TOKEN": ""}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        assert "ANTHROPIC_API_KEY=sk-test" in content
+        assert "# OSOJI_TOKEN=" in content
+        added = [a for a in actions if a["action"] == "added"]
+        assert len(added) == 2
+
+    def test_skips_existing_keys(self, tmp_path):
+        (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-existing\n")
+        values = {"ANTHROPIC_API_KEY": "sk-new", "OSOJI_TOKEN": "tok123"}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        assert "sk-existing" in content
+        assert "sk-new" not in content
+        assert "OSOJI_TOKEN=tok123" in content
+        skipped = [a for a in actions if a["action"] == "skipped"]
+        assert len(skipped) == 1
+        assert skipped[0]["key"] == "ANTHROPIC_API_KEY"
+
+    def test_empty_value_written_as_comment(self, tmp_path):
+        values = {"OSOJI_TOKEN": ""}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        assert "# OSOJI_TOKEN=" in content
+
+    def test_non_empty_value_written_bare(self, tmp_path):
+        values = {"OSOJI_TOKEN": "tok123"}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        assert "OSOJI_TOKEN=tok123" in content
+        assert "# OSOJI_TOKEN" not in content
+
+    def test_handles_commented_existing_key(self, tmp_path):
+        """A commented-out key (# OSOJI_TOKEN=) should NOT count as 'existing'."""
+        (tmp_path / ".env").write_text("# OSOJI_TOKEN=\n")
+        values = {"OSOJI_TOKEN": "tok123"}
+        actions = merge_dotenv(tmp_path, values)
+        content = (tmp_path / ".env").read_text()
+        assert "OSOJI_TOKEN=tok123" in content
+        added = [a for a in actions if a["action"] == "added"]
+        assert len(added) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,9 @@
 """Tests for osoji init module."""
 
 from pathlib import Path
+from unittest.mock import patch, call
 
-from osoji.init import merge_dotenv, merge_gitignore, merge_project_toml
+from osoji.init import merge_dotenv, merge_gitignore, merge_project_toml, run_init
 
 
 class TestMergeGitignore:
@@ -113,3 +114,42 @@ class TestMergeProjectToml:
         actions = merge_project_toml(tmp_path, project_slug=None)
         assert not (tmp_path / ".osoji.toml").exists()
         assert actions[0]["action"] == "skipped"
+
+
+class TestRunInit:
+    def test_non_interactive_creates_all_files(self, tmp_path):
+        """Non-interactive mode creates files with commented-out placeholders."""
+        run_init(root=tmp_path, interactive=False, provider="anthropic")
+        assert (tmp_path / ".gitignore").exists()
+        assert (tmp_path / ".env").exists()
+        env_content = (tmp_path / ".env").read_text()
+        assert "# ANTHROPIC_API_KEY=" in env_content
+
+    def test_non_interactive_respects_existing_env(self, tmp_path):
+        (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-existing\n")
+        run_init(root=tmp_path, interactive=False, provider="anthropic")
+        env_content = (tmp_path / ".env").read_text()
+        assert "sk-existing" in env_content
+
+    @patch("click.confirm", return_value=True)
+    @patch("click.prompt", side_effect=["sk-test-key", "", "myproject"])
+    def test_interactive_prompts_for_values(self, mock_prompt, mock_confirm, tmp_path):
+        run_init(root=tmp_path, interactive=True, provider="anthropic")
+        env_content = (tmp_path / ".env").read_text()
+        assert "ANTHROPIC_API_KEY=sk-test-key" in env_content
+        toml_content = (tmp_path / ".osoji.toml").read_text()
+        assert 'project = "myproject"' in toml_content
+
+    @patch("click.prompt", return_value="")
+    @patch("click.confirm", return_value=False)
+    def test_interactive_skips_when_declined(self, mock_confirm, mock_prompt, tmp_path):
+        """When user declines all prompts, no files are created."""
+        run_init(root=tmp_path, interactive=True, provider="anthropic")
+        assert not (tmp_path / ".gitignore").exists()
+        assert not (tmp_path / ".env").exists()
+
+    def test_non_interactive_openai_provider(self, tmp_path):
+        run_init(root=tmp_path, interactive=False, provider="openai")
+        env_content = (tmp_path / ".env").read_text()
+        assert "# OPENAI_API_KEY=" in env_content
+        assert "ANTHROPIC_API_KEY" not in env_content

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,3 +81,35 @@ class TestMergeDotenv:
         assert "OSOJI_TOKEN=tok123" in content
         added = [a for a in actions if a["action"] == "added"]
         assert len(added) == 1
+
+
+class TestMergeProjectToml:
+    def test_creates_toml_when_missing(self, tmp_path):
+        actions = merge_project_toml(tmp_path, project_slug="myproject")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert '[push]' in content
+        assert 'project = "myproject"' in content
+        assert len(actions) == 1
+        assert actions[0]["action"] == "added"
+
+    def test_skips_when_project_already_set(self, tmp_path):
+        (tmp_path / ".osoji.toml").write_text('[push]\nproject = "existing"\n')
+        actions = merge_project_toml(tmp_path, project_slug="newproject")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert 'project = "existing"' in content
+        assert "newproject" not in content
+        assert actions[0]["action"] == "skipped"
+
+    def test_adds_push_section_to_existing_toml(self, tmp_path):
+        (tmp_path / ".osoji.toml").write_text('default_provider = "openai"\n')
+        actions = merge_project_toml(tmp_path, project_slug="myproject")
+        content = (tmp_path / ".osoji.toml").read_text()
+        assert 'default_provider = "openai"' in content
+        assert '[push]' in content
+        assert 'project = "myproject"' in content
+        assert actions[0]["action"] == "added"
+
+    def test_no_project_slug_skips(self, tmp_path):
+        actions = merge_project_toml(tmp_path, project_slug=None)
+        assert not (tmp_path / ".osoji.toml").exists()
+        assert actions[0]["action"] == "skipped"

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -155,8 +155,9 @@ def test_env_overrides_project_policy(monkeypatch, tmp_path):
     assert config.config_snapshot["models"]["medium"]["source"] == "env"
 
 
-def test_non_anthropic_provider_requires_explicit_model(monkeypatch, tmp_path):
+def test_non_anthropic_provider_uses_builtin_defaults(monkeypatch, tmp_path):
     _clear_llm_env(monkeypatch)
 
-    with pytest.raises(RuntimeError, match="Set --model, OSOJI_MODEL, or OSOJI_MODEL_SMALL"):
-        Config(root_path=tmp_path, provider="openrouter")
+    config = Config(root_path=tmp_path, provider="openrouter")
+    assert config.provider == "openrouter"
+    assert config.config_snapshot["models"]["small"]["source"] == "builtin"

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -54,6 +54,7 @@ class TestBuildEnvelope:
             endpoint="https://api.example.com",
             token="tok_123",
             project_slug="myproject",
+            token_source="--token flag",
         )
         git_ctx = _mock_git_context()
         bundle = {"schema_version": "1", "files": []}
@@ -119,6 +120,48 @@ class TestResolveConfig:
                 endpoint=None, token="tok", project=None, root_path=tmp_path,
             )
         assert config.project_slug == "local_proj"
+
+    def test_token_source_from_cli_flag(self, tmp_path):
+        with patch.dict("os.environ", _env_without_osoji(OSOJI_ENDPOINT="https://api.example.com"), clear=True):
+            config = resolve_push_config(
+                endpoint=None, token="tok", project="p", root_path=tmp_path,
+            )
+        assert config.token_source == "--token flag"
+
+    def test_token_source_from_env_var(self, tmp_path):
+        with patch.dict(
+            "os.environ",
+            _env_without_osoji(OSOJI_ENDPOINT="https://api.example.com", OSOJI_TOKEN="tok"),
+            clear=True,
+        ):
+            with patch("osoji.push.dotenv_values", return_value={}):
+                config = resolve_push_config(
+                    endpoint=None, token=None, project="p", root_path=tmp_path,
+                )
+        assert config.token_source == "OSOJI_TOKEN env var"
+
+    def test_token_source_from_dotenv(self, tmp_path):
+        with patch.dict(
+            "os.environ",
+            _env_without_osoji(OSOJI_ENDPOINT="https://api.example.com", OSOJI_TOKEN="tok"),
+            clear=True,
+        ):
+            with patch("osoji.push.dotenv_values", return_value={"OSOJI_TOKEN": "tok"}):
+                config = resolve_push_config(
+                    endpoint=None, token=None, project="p", root_path=tmp_path,
+                )
+        assert config.token_source == ".env file"
+
+    def test_token_source_from_toml(self, tmp_path):
+        (tmp_path / ".osoji.toml").write_text(
+            '[push]\ntoken = "toml_tok"\n'
+            'endpoint = "https://cfg.example.com"\n'
+        )
+        with patch.dict("os.environ", _env_without_osoji(), clear=True):
+            config = resolve_push_config(
+                endpoint=None, token=None, project="p", root_path=tmp_path,
+            )
+        assert config.token_source == ".osoji.toml"
 
 
 class TestRunPush:
@@ -249,6 +292,28 @@ class TestRunPush:
 
         assert result.success is True
         mock_export.assert_called_once_with(git_repo)
+
+
+    @patch("osoji.push._post_envelope")
+    @patch("osoji.push._get_commits_since", return_value=[])
+    @patch("osoji.push._fetch_last_commit", return_value=None)
+    @patch("osoji.push.gather_git_context")
+    def test_push_401_shows_token_source(self, mock_git_ctx, mock_last, mock_commits, mock_post, git_repo):
+        mock_git_ctx.return_value = _mock_git_context()
+        mock_post.return_value = PushResult(
+            success=False,
+            status_code=401,
+            error_message="Authentication failed.",
+        )
+
+        with pytest.raises(click.ClickException, match="loaded from --token flag"):
+            run_push(
+                endpoint="https://api.example.com",
+                token="bad_tok",
+                project="osoji",
+                root_path=git_repo,
+                quiet=True,
+            )
 
 
 class TestLoadPushSection:


### PR DESCRIPTION
## Summary

- Add `osoji init` command for interactive project setup — configures `.gitignore`, `.env` placeholders, `.osoji.toml` with provider/model selection
- Safe for re-runs: skips duplicate entries, uses read-modify-write for TOML merges
- Interactive provider selection with sensible model defaults per provider
- Add push token provenance tracking — surfaces where config values were resolved from (CLI flag, env var, .env file, TOML) in output and 401 error messages
- Add `.osoji.local.toml.example` as a reference for local config overrides

## Commits

- `feat(init)`: register CLI command, gitignore/env/toml merge functions, interactive provider selection
- `fix(init)`: safe re-run handling, read-modify-write TOML updates
- `docs`: architecture list and tutorial updates
- `feat(push)`: token provenance diagnostics and `.osoji.local.toml.example`

## Test plan

- [ ] `osoji init` in a fresh directory creates expected files
- [ ] `osoji init` re-run does not duplicate entries
- [ ] Provider selection prompts and writes correct model config
- [ ] `osoji push` in non-quiet mode prints token source
- [ ] 401 error message includes token source hint
- [ ] `pytest tests/test_push.py` passes (token source tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)