### PR TITLE
chore: remove automated adversarial-review agent

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,4 +1,4 @@
-name: PR Review
+name: Instruction Integrity
 
 on:
   pull_request_target:
@@ -46,46 +46,3 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: `## Instruction files changed\n\nThis PR modifies control-plane files that affect agent behavior or CI enforcement:\n\n\`\`\`\n${files}\n\`\`\`\n\nThese changes deserve elevated scrutiny — they alter the security controls or agent instructions for this repository.`
             });
-
-  adversarial-review:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: anthropics/claude-code-action@26ddc358fe3befff50c5ec2f80304c90c763f6f8  # v1
-        with:
-          allowed_bots: "dependabot[bot]"
-          # This prompt is intentionally defined here, NOT read from CLAUDE.md.
-          # It runs via pull_request_target so the workflow version from main
-          # is always used, even if the PR modifies this file.
-          prompt: |
-            You are a security-focused code reviewer. Review this pull request
-            diff for the following concerns. Be concise — only flag genuine issues,
-            not style preferences.
-
-            SECURITY (highest priority):
-            - Data exfiltration: network calls to unexpected URLs, credential harvesting
-            - Hardcoded secrets: API keys, tokens, passwords in source code
-            - Weakened security controls: changes that disable checks, loosen validation,
-              or remove safety mechanisms
-            - Suspicious patterns: obfuscated code, encoded payloads, dynamic code execution
-
-            INSTRUCTION INTEGRITY (high priority):
-            - Changes to CLAUDE.md, .claude/, or .github/workflows/ are control-plane
-              modifications. Flag what changed and assess whether it weakens security posture.
-            - Changes to .github/workflows/pr-review.yml (this file) deserve the highest
-              scrutiny — they could disable this very review.
-
-            SUPPLY CHAIN (medium priority):
-            - Dependency additions or changes without corresponding requirements.lock update
-            - New network dependencies or external service calls
-            - Changes to build or publish configuration
-
-            Post your findings as a PR review comment. If nothing concerning is found,
-            post a brief "Security review: no issues found" comment.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/SUPPLY-CHAIN-SECURITY.md
+++ b/SUPPLY-CHAIN-SECURITY.md
@@ -86,24 +86,27 @@ Three lock files enforce hash-pinned reproducibility across the CI lifecycle:
 ### Instruction integrity
 
 AI agents follow instructions from files like CLAUDE.md and .claude/commands/.
-If these files are compromised, the agent follows malicious instructions. Two
-automated defenses address this:
+If these files are compromised, the agent follows malicious instructions. The
+automated defense is:
 
 **Instruction file flagging.** A CI job detects when a PR modifies control-plane
 files (CLAUDE.md, .claude/, .github/workflows/, .github/dependabot.yml) and
-adds an `instruction-files-changed` label. This ensures control-plane changes
-are visible even in a quick PR summary scan.
+adds an `instruction-files-changed` label. This is a regex-based check — no
+LLM, no tool execution — so it is not itself susceptible to prompt injection.
+Control-plane changes become visible even in a quick PR summary scan, which
+ensures elevated human scrutiny for the changes most capable of weakening
+security posture.
 
-**Adversarial review agent.** A separate AI agent runs in CI via
-`anthropics/claude-code-action`, reviewing every PR for security concerns. Its
-prompt is defined **inline in the workflow file** — it does not read CLAUDE.md
-or any repository instruction file. The workflow uses `pull_request_target`,
-which always runs the workflow version from main, not the PR branch. This means
-a PR cannot weaken the reviewer's prompt and add a backdoor simultaneously.
-
-To compromise the reviewer, an attacker would need to merge a modified workflow
-into main — which requires passing the current reviewer. This circular
-dependency is the core security property.
+An earlier version of this workflow also ran an "adversarial review agent"
+(an LLM reviewing every PR diff for security concerns) via
+`anthropics/claude-code-action`. That agent was removed: automatically feeding
+untrusted PR content to an LLM that has any write capability is, by
+construction, a prompt-injection target, and the available mitigations (tool
+lockdown, permission scoping) patch symptoms rather than the underlying shape.
+When a security-focused LLM review of a specific PR is wanted, a maintainer
+can invoke Claude on demand (`@claude` in a PR comment via
+`.github/workflows/claude.yml`, or locally via Claude Code) after deciding the
+PR is worth engaging with.
 
 ### Pre-commit safety
 
@@ -165,9 +168,10 @@ These controls make compromise **costly and visible**, not impossible.
 - **Admin override.** The repository admin can disable branch protection with
   a single API call. The GitHub audit log records this, but no automated
   system monitors the audit log.
-- **Prompt injection.** The adversarial review agent is an LLM and can
-  potentially be manipulated by carefully crafted PR content. This is an
-  arms race between prompt robustness and attacker creativity.
+- **Prompt injection (manual invocation).** When a maintainer invokes Claude
+  on demand (via `@claude` in a PR comment, or locally), the diff or comment
+  content can attempt prompt injection. Risk is bounded by the workflow's
+  declared permissions and whatever tools the invocation enables.
 - **Slow poisoning.** Many small, individually benign changes that combine
   into a vulnerability are not detectable by per-PR review.
 - **Advisory lag.** pip-audit and Dependabot only catch vulnerabilities after


### PR DESCRIPTION
## Summary

Remove the `adversarial-review` job from `.github/workflows/pr-review.yml` and
update `SUPPLY-CHAIN-SECURITY.md` to reflect the new threat model.

## Why

**Shape of the risk.** Automatically feeding untrusted PR content to an LLM
that has any write capability is a prompt-injection target by construction.
The available mitigations (tool lockdown, permission scoping) patch symptoms
rather than the underlying shape.

**Current signal is zero.** The job has been failing on every PR for weeks
due to upstream [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)
— "OIDC token exchange rejects `pull_request_target` events." Earlier
attempts (#45, #47, #53, #54) bounced between two ends of this upstream
bug. Even if fixed, the prompt-injection issue above makes automatic
invocation on unreviewed input the wrong shape.

**The useful half is preserved.** The regex-based `instruction-integrity`
job (labels PRs that touch `CLAUDE.md` / `.claude/` / `.github/workflows/` /
`.github/dependabot.yml`) stays. It is the highest-value check here and is
not susceptible to prompt injection — no LLM, no tool execution, just
grep-and-label.

**On-demand LLM review is still available.** The separate
`.github/workflows/claude.yml` triggers on `@claude` mentions in PR
comments, so a maintainer can invoke a security-focused review on demand
after deciding a PR is worth engaging with.

## Changes

- `.github/workflows/pr-review.yml` — delete the `adversarial-review` job;
  rename workflow to "Instruction Integrity" to reflect what it actually does.
- `SUPPLY-CHAIN-SECURITY.md` — replace the "Adversarial review agent"
  paragraph with rationale for its removal; update the "Prompt injection"
  known-limitations entry to scope it to manual invocation.

## Test plan

- [ ] CI passes on this PR (no job gets deleted that we still rely on).
- [ ] `instruction-integrity` job still runs and labels this PR (since it
      touches `.github/workflows/` and `SUPPLY-CHAIN-SECURITY.md` — well, the
      latter isn't a control-plane file, but the workflow file is).
- [ ] No `adversarial-review` red X on future Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)