### PR TITLE
wiki: Claim Builder, string-contract taxonomy, falsifiability framing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,25 @@ In non-quiet mode, `osoji push` prints which source each config value was resolv
   this distinction — the goal is to convert silent value-level mismatches into loud
   name-level errors, not merely to "extract constants."
 
+- **Closed-set taxonomies require an `other` outlet, and `other`-rate is itself
+  a metric.** Whenever the system introduces a closed-set classification (gap
+  types, string-contract classes, evidence kinds, severity scales), include
+  an explicit `other`/`uncategorized` value as a safety valve. The downstream
+  handler treats `other` as a request for review rather than silently shoehorning
+  into the closest fit. The proportion of items routed to `other` is then a
+  first-class metric on the taxonomy's adequacy: rising rate signals revision.
+  This is how taxonomies stay falsifiable engineering claims rather than
+  ossifying into asserted theorems. See `wiki/specs/0001-v1-foundation.md#epistemological-note`.
+
+- **Mechanical layers gather; LLM layers reason; both are answerable to the
+  regression evaluator.** Where to put the boundary between mechanical
+  (cheap, exhaustive, reliable) and LLM (judgment, world knowledge) is decided
+  per-task by measurement, not by rule. The Claim Builder is allowed to be
+  ignorant of stdlib semantics (the LLM has world knowledge in its weights);
+  the LLM is allowed to be ignorant of cross-file reference graphs (the
+  mechanical layer has the FactsDB). Both layers report to the regression
+  evaluator, which is what tells us whether a given division is working.
+
 ## Style
 
 - Python 3.11+, type hints throughout

--- a/wiki/concepts/self-sufficient-claims.md
+++ b/wiki/concepts/self-sufficient-claims.md
@@ -1,0 +1,120 @@
+---
+id: "0003"
+title: Self-sufficient claims and the Claim Builder
+type: concept
+status: draft
+created: 2026-04-29
+updated: 2026-04-29
+related: [concepts/three-gap-theory.md, concepts/string-contract-taxonomy.md, specs/0001-v1-foundation.md]
+---
+
+## The problem this solves
+
+A naive Triage architecture gives the LLM a finding plus tool access (grep, read, list) and lets it explore the codebase to decide. Token cost is unbounded — it scales with how aggressive the LLM is at exploration. For a codebase of nontrivial size, this becomes the dominant audit cost and the dominant audit latency.
+
+A **self-sufficient claim** is a structured object that contains everything Triage needs to apply the [TP-predicate rubric](three-gap-theory.md#the-frame) — case-for, case-against, positional context, relevant shadow docs — assembled mechanically before Triage runs. Triage decides each claim in one LLM call without exploration. Token cost becomes bounded and predictable; it scales linearly with finding count.
+
+This is the same insight gepa formalizes for general agentic optimization: rich traces beat scalar rewards because the reasoner doesn't need to retrieve. Applied at the Triage layer, the principle is **mechanical layers gather; LLM layers reason**. The boundary is empirical (decided per-finding-class by what the Claim Builder bootstrap shows the LLM actually consults) and revisable.
+
+## What goes in a claim
+
+A claim's structure is the [Finding schema](../specs/0001-v1-foundation.md#the-finding-schema-a) plus a richer Evidence list. Conceptually:
+
+```
+Hypothesis:
+  gap_type, contract_claim, observed_behavior, location
+
+Evidence FOR (case for confirming):
+  - "no references to `foo` in any of N files indexed in FactsDB"
+  - "literal `failed` in test/test_x.py:45 (assert) and src/y.py:12 (raise)"
+  - "docstring claims sorted output; function uses set() which is unordered"
+
+Evidence AGAINST (case for dismissing):
+  - "symbol `foo` appears in base class `BaseHandler` — possible interface dispatch"
+  - "literal `404` appears with `status_code=` token, in function called `handle_response`"
+  - "function is registered via `@route` decorator at line 8"
+
+Positional context (without semantic interpretation):
+  - "literal in stdlib constants set: yes / no / unknown"
+  - "name pattern matches a framework convention (positional flag, not verdict): yes / no"
+  - "surrounding 5 lines of code"
+  - "enclosing function signature"
+
+Relevant shadow docs (compressed-code Evidence):
+  - <file>.shadow.md (always)
+  - _directory.shadow.md (when potentially architectural)
+  - _root.shadow.md (when potentially project-level)
+
+Open questions Triage must answer:
+  - "does the AGAINST evidence plausibly explain the zero-reference signal?"
+  - "is this literal class 1, 2, 3, 4, or 5 per string-contract-taxonomy?"
+
+Insufficient-evidence flag:
+  - if the Claim Builder cannot fill required Evidence kinds, flag the claim
+    so Triage escalates to exploration mode rather than guessing.
+```
+
+## Division of labor: positional vs semantic
+
+The Claim Builder produces **positional** evidence — where in the code does this literal/symbol/comment live, what's around it, what's its enclosing function or module. The LLM provides **semantic interpretation** — what 404 *means*, whether a particular framework registration is real, whether two surrounding contexts are about the same concept.
+
+This division is load-bearing. The mechanical layer is *deliberately* ignorant of stdlib semantics, RFC values, framework conventions. Any attempt to embed such knowledge mechanically recreates the catalog anti-pattern (see [pipeline engineering principles](../../CLAUDE.md#pipeline-engineering-principles)) at the evidence-gathering layer. The LLM has world knowledge in its weights; the Claim Builder positions the artifact so that knowledge can fire.
+
+Concrete example: an Evidence kind `surrounding_code_context` (here are the 5 lines around the literal, plus the enclosing function signature) is doing more semantic work than a kind `is_http_code: bool`. The first composes with LLM knowledge; the second tries to encode it.
+
+## Shadow docs as the primary compressed-code substrate
+
+osoji already maintains a three-tier shadow doc layout (`<file>.shadow.md`, `_directory.shadow.md`, `_root.shadow.md`) — the digested form of code at three scopes. Self-sufficient claims include the relevant shadow docs as Evidence rather than raw source.
+
+| Substrate | Token cost | Fidelity | When to include |
+|---|---|---|---|
+| Raw source | High | Full | Only when shadow doc loses critical detail (rare; flagged via insufficient-evidence) |
+| `<file>.shadow.md` | Low | Structural | Always |
+| `_directory.shadow.md` | Low | Architectural | When a potential description gap could be architectural |
+| `_root.shadow.md` | Low | Project-level | When a potential description gap could be project-level |
+
+This makes shadow docs the *primary* Evidence kind for most findings. It also amortizes osoji's existing investment in shadow generation — the most expensive thing osoji already does is reused as Triage input rather than discarded after detector candidate filtering.
+
+## Bootstrap path
+
+We don't claim a priori to know what evidence is sufficient for each finding category. We measure.
+
+1. **Observe.** Run Triage in *exploration mode* on a small representative set — give the LLM read/grep/list tools, let it decide. Log every tool call: what was grep'd, what was read, what was concluded.
+2. **Mine.** Analyze the traces. For each finding category, what Evidence kinds did the LLM consistently consult? Patterns emerge: `dead_code` always involved cross-file references, base class hierarchy, and string-literal occurrences of the symbol name; string-contract candidates always involved surrounding-code context plus the sibling file's surrounding code.
+3. **Mechanize.** Build the Claim Builder to produce exactly those Evidence kinds, using only successful (correct-verdict) exploration traces as the spec. The LLM's exploration becomes the *requirements doc* for the mechanical layer.
+4. **Validate by ablation.** Run Triage in claim-only mode against the same set. If verdicts match the exploration baseline, mechanization is sufficient. If they diverge, a missing Evidence kind explains the gap. Add it; repeat.
+
+Two subtleties worth being explicit about: only mine *correct* exploration traces (the LLM sometimes wanders into hallucinated paths and we don't want to mechanize bad exploration), and refresh the bootstrap periodically as the [sweep → fixture corpus](../specs/0001-v1-foundation.md#sweep--fixture-corpus-c-data) on new codebases surfaces new failure modes. Patterns mined from osoji-on-osoji may not generalize.
+
+## Escalation path
+
+When the Claim Builder cannot fill a required Evidence kind — a referenced file is missing, a symbol's facts are malformed, a contract's sibling file is outside the indexed scope — the claim carries an `insufficient_evidence` flag. Triage handles this by escalating to exploration mode for that single claim: the LLM gets tool access and decides with retrieval. Cost stays bounded because the escalation rate is itself a metric and most claims resolve one-shot.
+
+The escalation rate is also a quality signal on the Claim Builder. A rate that climbs over time signals the schema needs revision; the bootstrap loop runs again.
+
+## Optimization (v2): gepa over the Claim Builder schema
+
+There are two distinct optimization targets, cleanly separable:
+
+- **Triage prompt** evolves how the LLM *reasons over* given evidence. Mutates the rubric, the rubric examples, the question framing.
+- **Claim Builder schema** evolves *what evidence is gathered*. Mutates which Evidence kinds to include, how much surrounding context per kind, how to summarize.
+
+Either can run gepa independently against the regression evaluator. They could even compete: a Claim Builder mutation that drops an Evidence kind shouldn't hurt verdict accuracy if the kind was non-load-bearing. That's *exactly* what gepa-style ablation is for. Over time, the Claim Builder converges to the minimum-sufficient evidence schema — which is also the cheapest token-wise.
+
+This requires that the Claim Builder schema be a **configuration object** (a list of evidence-kind-builders to invoke per claim), not a hardcoded class, so gepa can mutate the list without code changes. Designed-for in v1; built in v2.
+
+## Properties this gives osoji
+
+- **Bounded token cost.** Audit cost = N × (avg claim size) × (per-token cost) + escalation surcharge. Predictable, capacity-planneable.
+- **Auditable reasoning.** Every verdict is traceable to a structured claim. The "why did osoji say this is dead code?" question has a complete answer in the claim record.
+- **Reproducible reasoning.** Same claim → same decision (modulo LLM stochasticity, which the regression framework already measures).
+- **Honest evidence schema.** What's in a claim is what we *measured* the LLM uses, not what we *guessed* it should.
+- **Optimizable.** The schema itself is a gepa target.
+- **Empirically grounded.** Falsifiable at every layer: claims that triggered escalation tell us where the schema is incomplete; verdict-disagreement between claim-mode and exploration-mode tells us how good the mechanization is.
+
+## Open questions
+
+- **Bootstrap test set composition.** Should it be osoji-on-osoji only, or include sweep results from diverse projects? Probably a mix; resolve when the first bootstrap runs.
+- **Claim batch size for Triage.** How many self-sufficient claims fit in a single LLM call before context-window or attention degradation hurts? Empirical; benchmark during step 3 of the v1 order of operations.
+- **Per-Evidence-kind weighting.** Should the schema configuration include a weight hint per Evidence kind (already a field in the v1 `Evidence` dataclass), or let the LLM weight implicitly? The honest answer is probably "let the LLM weight; remove `weight_hint` if measurement shows it's unused."
+- **What's the minimum-sufficient claim format for ablation?** When gepa drops Evidence kinds, what's the floor below which decisions degrade? Will tell us which kinds are doing real work.

--- a/wiki/concepts/string-contract-taxonomy.md
+++ b/wiki/concepts/string-contract-taxonomy.md
@@ -1,0 +1,65 @@
+---
+id: "0002"
+title: String-contract taxonomy
+type: concept
+status: draft
+created: 2026-04-29
+updated: 2026-04-29
+related: [concepts/three-gap-theory.md, concepts/self-sufficient-claims.md, specs/0001-v1-foundation.md]
+---
+
+## Why a taxonomy
+
+Hard-coded strings and literals are the most common false-positive class in current osoji. The `obligations.py` detector runs as pure-Python pattern matching — no LLM filter — and treats every shared literal as a potential contract. This conflates several distinct semantic classes, each requiring different Triage logic.
+
+This page defines the rubric Triage applies when reasoning about literal-based findings. It is **not** detector logic. The detector continues to enumerate candidate shared literals via cheap pattern matching; classification happens in Triage with the LLM, with mechanically-assembled evidence as input.
+
+## The five classes
+
+| Class | What it looks like | Real contract? | Failure mode if drift | Triage response |
+|---|---|---|---|---|
+| **Named project obligation** | One file declares a constant (`MAX_RETRIES = 3`); another file uses the bare literal in a semantically-related context (`if attempts < 3`). The constant has a name; the literal is duplicating it. | **Yes** | Drift produces silent disagreement | Confirm; suggest `if attempts < MAX_RETRIES` |
+| **Unnamed project obligation** | Two files use the same bare literal in clearly-related semantic roles (both look like retry counts), but no shared constant exists yet. | **Yes** (latent) | Drift produces silent disagreement | Confirm; suggest extracting a shared constant |
+| **Ecosystem convention** | A literal whose meaning is defined *outside* the project: HTTP codes (`200`, `404`), file modes (`0o644`), DNS port (`53`), MIME types (`"application/json"`), Unix signals, RFC-defined strings, language-version literals. | **No** — the contract is with the external standard, not within the project | None — both endpoints reference the standard independently | Dismiss with reasoning: standard external value |
+| **Magic-constant duplication (ambiguous)** | A literal repeats across files, the surrounding code is *not* clearly the same concept, but it isn't obviously coincidental either. | **Sometimes** | Possible silent disagreement; possibly nothing | Examine: if the two sites *should* agree, confirm; if coincidence, dismiss |
+| **Coincidental duplication** | The same literal appearing in test fixtures and production code, or in unrelated semantic roles (`user_id = 12345` in a test; `12345` in a numeric calculation). | **No** | None | Dismiss as coincidence |
+| **Other** | Doesn't fit any class. | — | — | Route to the broadest-context Triage with explicit "uncategorized" verdict reasoning. Counts toward the [CE-gap metric](#how-this-taxonomy-is-used). |
+
+Hybrid classifications are legitimate. A literal that is *both* an ecosystem convention *and* a named project obligation (e.g., a project defines `STATUS_NOT_FOUND = 404` and uses it via the named constant) gets classified to both classes; Triage's response is the conjunction (confirm the named-obligation aspect; dismiss the bare-`404` complaint). The Finding schema accommodates a list of class hypotheses, not a single label.
+
+## Why pure-rule matching can't decide
+
+A rule that flags every shared literal will flag standard HTTP codes (`200` appearing in three handler files) just as readily as it flags real project obligations. The literal pattern is identical; only the semantic status differs, and that status requires general knowledge ("404 is a standard HTTP code defined in RFC 7231") that a pure-rule check does not possess.
+
+This is the structural reason the v1 plan routes obligations through the unified [Triage stage](../specs/0001-v1-foundation.md#the-triage-stage-b). Triage receives mechanical positional evidence (the literal, its surrounding code, sibling occurrences) and applies its general knowledge to classify. The rubric above is what Triage's prompt encodes.
+
+This is **not** a claim that "mechanical filters never decide" as a general principle — that would be a slogan. It is an empirical observation that for *literal-based contract findings*, the world knowledge required to distinguish project-internal contracts from ecosystem conventions is stored in the LLM's weights, not in any feasible rule database. Other parts of osoji's pipeline are happy to be purely mechanical (file walking, hashing, AST parsing). The boundary is empirical, decided per-task.
+
+## What the detector does and doesn't do
+
+The string-contract detector (file-tuple class per [three-gap minimum context](three-gap-theory.md#minimum-context-invariants)):
+
+- Continues cheap pattern matching to enumerate **candidate** shared literals across file pairs. Cheap candidate filtering is fine.
+- Attaches per candidate, via the [Claim Builder](self-sufficient-claims.md): the originating file/site, the consuming file/site, the surrounding code in both, and any positional signals that might inform classification (e.g. "literal is preceded by `status_code=`," "literal appears in a function called `handle_response`"). **Positional, not semantic.** The detector does not pre-classify; it presents the dossier.
+- **Never** emits a finding directly. Pure-rule emission is the failure mode this taxonomy exists to prevent.
+
+Triage applies the rubric and produces a finding (with verdict, confidence, reasoning) for each class-1 / class-2 case and contested class-4 cases. Class-3 and class-5 cases are dismissed at Triage with reasoning recorded.
+
+## How this taxonomy is used
+
+This is a **descriptive taxonomy** (used as Triage rubric vocabulary), not a dispatch taxonomy. Two implications for falsifiability:
+
+- **CE-gap rate**: proportion of literal-based findings classified as `other`. If this rises above ~5% on a representative corpus, the taxonomy is missing a class.
+- **ME-overlap is acceptable** because Triage routes hybrids to multi-class responses, not to multiple analysis pipelines. A high overlap rate isn't a failure mode; the rubric is robust to it.
+
+These metrics live alongside per-detector TP/FP in the [prompt regression evaluator](../specs/0001-v1-foundation.md#sweep--fixture-corpus-c-data).
+
+## Open questions
+
+- **How aggressive should the candidate filter be?** A purely permissive filter (every literal repeated across files) over-feeds Triage and burns LLM tokens; a heuristic skip-list (numeric literals < 10, single-character strings) is the kind of catalog the [pipeline engineering principles](../../CLAUDE.md#pipeline-engineering-principles) warn against. The honest answer is probably "permissive filter + Triage rubric does the work," monitored by the regression evaluator. Resolve when Claim Builder schema is implemented.
+- **Should Evidence carry a `class_hypothesis` field?** A pre-Triage classifier that proposes a class (informed by the literal's shape, location, and surrounding code) could speed Triage. Defer until the unclassified-Triage baseline is measured per the [self-sufficient claims bootstrap path](self-sufficient-claims.md#bootstrap-path).
+- **Do version strings (`"v1"`, `"2.4.1"`) form a sixth class?** They look ecosystem-convention-ish but are project-specific. Catalog cases when they appear; promote to class if pattern emerges.
+
+## Why this matters
+
+This taxonomy is the wedge for the longstanding complaint that osoji "likes seeing strings produced one place and consumed elsewhere" without a coherent model for what makes a real problem. The five classes give Triage a defensible rubric: project-originated obligations get confirmed (with the named/unnamed split governing the suggested fix); ecosystem conventions get dismissed; ambiguous cases get reasoned about case-by-case rather than swept either way. The classes are descriptive — used to articulate verdicts, not to gate analysis — so non-MECE among them is acceptable and doesn't corrupt behavior.

--- a/wiki/concepts/three-gap-theory.md
+++ b/wiki/concepts/three-gap-theory.md
@@ -5,18 +5,19 @@ type: concept
 status: draft
 created: 2026-04-29
 updated: 2026-04-29
-related: [specs/0001-v1-foundation.md]
+related: [specs/0001-v1-foundation.md, concepts/string-contract-taxonomy.md, concepts/self-sufficient-claims.md]
 ---
 
 ## The frame
 
-Every code-quality finding is a hypothesis about a **gap** between what the code claims and what the code does. There are three gap types, and every existing osoji detector maps cleanly onto one.
+Every code-quality finding in osoji is a hypothesis about a **gap** between what the code claims and what the code does. There are three gap types, and every existing osoji detector maps onto one (with an explicit `uncategorized` outlet for findings that don't fit — see [How this taxonomy is used](#how-this-taxonomy-is-used-and-what-would-make-it-wrong) below).
 
 | Gap type | What's claimed | What actually happens | Existing detectors |
 |---|---|---|---|
 | **Reachability** | declared / claimed to be used | unreachable | `dead_code`, `dead_symbol`, `dead_parameter`, `unactuated_config`, `orphaned_file`, `unused_dependency` |
 | **Description** | described one way (comment, docstring, name, type) | behaves another | `stale_content`, `incorrect_content`, `misleading_claim`, `stale_comment`, `latent_bug` (when it violates a stated type/contract) |
 | **Contract** | implicit cross-component agreement (shared string, schema, ABI) | broken | `obligation_violation`, cross-file string drift, `latent_bug` (when it violates an implicit invariant), schema/ABI mismatch |
+| **Uncategorized** | (does not fit cleanly) | — | safety valve; routed to broadest-context Triage and counted as a metric on taxonomy adequacy |
 
 A finding is a true positive iff three predicates hold:
 
@@ -30,29 +31,50 @@ This frame generalizes cleanly to absorb tree-sitter queries, OSS scanner output
 
 ## Minimum-context invariants
 
-A second invariant the theory imposes: **each gap type has a minimum propose-time context** below which proposals are structurally FP-prone. Conflating these contexts — running every detector against the same per-file substrate — has been a structural source of FPs in current osoji.
+Each gap type has a **minimum propose-time context** below which proposals are structurally false-positive-prone. Conflating these contexts — running every detector against the same per-file substrate — has been a structural source of FPs in current osoji.
 
 | Gap type | Minimum propose-time context | Why |
 |---|---|---|
 | **Reachability** | **Project-graph context** | A file in isolation can at best say "no references appear in this file." That's the perspective that produces FPs when a symbol is referenced via dynamic dispatch, dataclass→asdict chains, framework registration, or implicit re-exports. The FactsDB is the project graph; today it is consulted at filter and triage time but not at *propose* time, which is the wrong gate. |
-| **Description** | **Per-file context** | The file containing the claim and the file containing the behavior, usually the same file. Per-file reading is the right window for stale comments, misleading docstrings, and latent bugs that can be ruled in or out from a function body alone. Shadow-doc-style isolation is a feature here, not a bug. |
+| **Description** | **Smallest sufficient shadow scope** (file / directory / root) | A claim can drift relative to its adjacent code, its directory's pattern, or the project's architecture. The right propose-time context is the smallest shadow scope that contains both the claim and the candidate-violating behavior. See [Description gap scope spectrum](#description-gap-scope-spectrum) below. |
 | **Contract** | **File-tuple context** | The N files (typically two) sharing an implicit or explicit contract. `obligations.py` already groups by file pair; the rest of the contract-gap detectors should follow. |
 
-Detectors that need broader context than their declared window — for instance, a contract detector that wants to confirm a third file is unaffected — declare it explicitly via the Evidence schema rather than reaching for ambient access. Triage retains global cross-file capability as a safety net, but the goal is to stop generating doomed findings at the source rather than relying on Triage to catch them after the LLM has already committed to a context-blind perspective.
+Detectors that need broader context than their declared window — for instance, a contract detector that wants to confirm a third file is unaffected — declare it explicitly via the [Evidence schema](../specs/0001-v1-foundation.md#the-finding-schema-a) rather than reaching for ambient access. Triage retains global cross-file capability as a safety net, but the goal is to stop generating doomed findings at the source rather than relying on Triage to catch them after the LLM has already committed to a context-blind perspective.
+
+### Description gap scope spectrum
+
+Description gaps are not all local. Three sub-cases the detector must distinguish:
+
+- **Local description drift** — a comment or docstring claims X about the function or class immediately around it; per-file context (`<file>.shadow.md`) is sufficient. Examples: `# returns sorted list` above a function that no longer sorts; a docstring describing parameters that have since been renamed.
+- **Architectural description drift** — a module-level docstring or directory README claims a pattern that the rest of the directory has since deviated from. Needs `_directory.shadow.md` plus the file. Examples: a `_handlers.py` docstring says "all handlers register via `@route`, no exceptions" but a sibling file added an exception.
+- **Project-level description drift** — a top-level README, architecture doc, or `_root.shadow.md` claim that components elsewhere now violate. Needs `_root.shadow.md`. Examples: README says "stateless workers" but one worker now caches per-request state; contributing guide claims "all detectors are language-agnostic" but a new one hardcodes Python conventions.
+
+osoji's existing three-tier shadow doc layout is the right substrate. Per-file detectors that propose description gaps should consume the *smallest* scope that brackets both the claim and a candidate-violating behavior — not the largest. Larger scopes invite hallucinated drift; smaller scopes miss architectural-level claims. Triage retains broader scopes as a safety net.
+
+## How this taxonomy is used (and what would make it wrong)
+
+Three-gap theory serves two distinct uses, and the falsifiability metric is different for each.
+
+- **Generative use** — the taxonomy frames what osoji is looking for. A finding that doesn't fit any gap type is either out of scope (osoji doesn't aim to detect it) or a signal that the taxonomy is missing a category. **Falsified by CE-gap rate**: the proportion of findings classified `gap_type=uncategorized`. If this rises above ~3% on a representative corpus, the taxonomy is missing a category.
+- **Analytical use** — the gap_type dispatches a finding to the right minimum-context detector class. Two findings classified into different gap types should require different analysis pipelines. **Falsified by ME-overlap rate**: the proportion of findings that legitimately fit multiple gap types and require analyses from more than one minimum-context class. Some overlap is acceptable (e.g., `latent_bug` straddling description/contract by classification rule); structural overlap signals the dispatch boundary is wrong.
+
+Both metrics are tracked alongside per-detector TP/FP rates by the [prompt regression evaluator](../specs/0001-v1-foundation.md#sweep--fixture-corpus-c-data). The taxonomy is treated as a falsifiable engineering claim, not a theorem.
 
 ## Why this matters
 
 Before three-gap: each detector independently decided what "wrong" means; six different verification gates, six schemas, six surfaces to debug. Improving any one of them did nothing for the others.
 
-After three-gap: one definition of true-positive, one rubric, one Triage stage. Improving the rubric improves every detector. The propose-time minimum-context invariant directly attacks the FP class the user has been fighting.
+After three-gap: one definition of true-positive, one rubric, one Triage stage. Improving the rubric improves every detector. The propose-time minimum-context invariant directly attacks the FP class the user has been fighting. The `uncategorized` outlet plus CE-gap and ME-overlap rates make the taxonomy honestly falsifiable rather than asserted.
 
 ## Relation to other terms in the wiki
 
-- The [Finding schema](../specs/0001-v1-foundation.md#the-finding-schema-a) carries `gap_type` as a typed field; this is its source of truth.
+- The [Finding schema](../specs/0001-v1-foundation.md#the-finding-schema-a) carries `gap_type` as a typed field with an `uncategorized` value; this is its source of truth.
 - The [Triage stage](../specs/0001-v1-foundation.md#the-triage-stage-b) consumes findings and applies the three-predicate verification.
-- The [Evidence model](../specs/0001-v1-foundation.md#evidence-gathering) records, per Evidence kind, what a piece of evidence contributes to which predicate.
+- [Self-sufficient claims](self-sufficient-claims.md) is the mechanism by which evidence reaches Triage.
+- [String-contract taxonomy](string-contract-taxonomy.md) is the sub-taxonomy Triage uses when reasoning about contract gaps over hard-coded literals.
 
 ## Open questions
 
-- **Do all latent-bug variants fit cleanly into "description" or "contract"?** The plan splits them by whether the violated invariant is *stated* (description) or *implicit* (contract). There are likely edge cases — e.g. a violated type hint that exists only at runtime via `__class__` checks — that could go either way. Catalog cases as they appear.
+- **Do all `latent_bug` variants fit cleanly into "description" or "contract"?** The current rule splits them by whether the violated invariant is *stated* (description) or *implicit* (contract). There are likely edge cases — e.g. a violated type hint that exists only at runtime via `__class__` checks — that could go either way. Catalog cases as they appear; the `uncategorized` outlet absorbs unclear ones until the rule is refined.
 - **Tree-sitter queries: are they detectors, or evidence sources?** Probably both, depending on how the query is wired. A query that says "every public function named `_foo`" is a detector (proposes findings); a query that says "every call site of this function" is evidence (consumed by reachability detectors). The Finding schema doesn't need to distinguish; the wiring layer does.
+- **Is project-graph context sufficient for reachability gaps in the presence of dynamic dispatch / metaprogramming?** Probably not at the limit. Defer until measurement shows it matters.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -11,7 +11,9 @@ Tooling: [`osoji-wiki`](https://github.com/osojicode/osoji-wiki) — MCP server 
 
 ## Concepts
 
-- [Three-gap theory](concepts/three-gap-theory.md) — the unifying frame for every osoji finding: reachability gaps, description gaps, contract gaps, with minimum-context invariants.
+- [Three-gap theory](concepts/three-gap-theory.md) — the unifying frame for every osoji finding: reachability gaps, description gaps, contract gaps, with minimum-context invariants and a falsifiability framing.
+- [String-contract taxonomy](concepts/string-contract-taxonomy.md) — the five-class Triage rubric for hard-coded literals: named obligation, unnamed obligation, ecosystem convention, magic-constant duplication, coincidence.
+- [Self-sufficient claims and the Claim Builder](concepts/self-sufficient-claims.md) — how claims are mechanically assembled to be Triage-decidable in one shot; bootstrap from exploration; positional vs semantic division of labor; shadow-doc-primary substrate.
 
 ## Decisions
 
@@ -19,7 +21,7 @@ Tooling: [`osoji-wiki`](https://github.com/osojicode/osoji-wiki) — MCP server 
 
 ## Detectors
 
-_(none yet — populated as detectors are migrated to the unified Finding/Triage architecture in v1 step 4)_
+_(none yet — populated as detectors are migrated to the unified Finding/Triage architecture in v1 step 5)_
 
 ## Sources
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -13,3 +13,9 @@ Append-only changelog of wiki edits. Format: `YYYY-MM-DD <op> <path> — <one-li
 2026-04-29 write specs/0002-wiki-bootstrap.md — bootstrap: record this session's plan
 2026-04-29 write concepts/three-gap-theory.md — bootstrap: define reachability/description/contract gap taxonomy and minimum-context invariants
 2026-04-29 write decisions/0002-language-choice.md — bootstrap: capture decision to stay on Python for v1 with a sidecar door left open
+2026-04-29 edit concepts/three-gap-theory.md — add `uncategorized` outlet; refine description-gap minimum context to scope spectrum (file/directory/root); add CE-gap and ME-overlap falsifiability framing
+2026-04-29 write concepts/string-contract-taxonomy.md — five-class Triage rubric (named obligation, unnamed obligation, ecosystem convention, magic-constant duplication, coincidence) plus `other` outlet; framed as descriptive Triage rubric, not detector logic
+2026-04-29 write concepts/self-sufficient-claims.md — Claim Builder design: bootstrap from exploration traces, positional vs semantic division of labor, shadow-doc-primary substrate, escalation path, gepa-optimizable schema as v2 target
+2026-04-29 edit specs/0001-v1-foundation.md — Claim Builder replaces ad-hoc evidence gathering; new step 4 (exploration-mode bootstrap and ablation); add Epistemological Note section with four-layer foundation (stipulated/taxonomic/engineering/measured); Verification gains escalation-rate, falsifiability-metrics, and bootstrap-convergence criteria
+2026-04-29 edit index.md — add string-contract-taxonomy and self-sufficient-claims entries; update detector section reference (step 4 → 5)
+2026-04-29 edit ../CLAUDE.md — add closed-set-taxonomies-need-`other` and mechanical-vs-LLM-boundary-decided-by-measurement to pipeline engineering principles

--- a/wiki/specs/0001-v1-foundation.md
+++ b/wiki/specs/0001-v1-foundation.md
@@ -68,7 +68,7 @@ Triage continues to operate with global cross-file context as a safety net, but 
 
 Each detector declares its required propose-time context. Three classes:
 
-- **Per-file detectors** read one source file (and that file's shadow doc). Right window for description gaps. Examples: `stale_comment`, `misleading_claim`, `latent_bug` when the bug is local, doc-accuracy errors. Shadow generation continues to feed these — shadow docs are repositioned as *the input to per-file detectors*, not as the universal substrate from which all findings are extracted.
+- **Per-file detectors** read one source file plus the smallest shadow scope that brackets the claim and the candidate behavior — `<file>.shadow.md` for local drift, `_directory.shadow.md` for architectural drift, `_root.shadow.md` for project-level drift. See [description gap scope spectrum](../concepts/three-gap-theory.md#description-gap-scope-spectrum) for the three sub-cases. Right window for description gaps. Examples: `stale_comment`, `misleading_claim`, `latent_bug` when the bug is local, doc-accuracy errors. Shadow generation continues to feed these — shadow docs are repositioned as *the input to per-file detectors at the appropriate scope*, not as the universal substrate from which all findings are extracted.
 - **Project-graph detectors** read FactsDB plus a candidate symbol's source file. Right window for reachability gaps. Examples: `dead_code`, `dead_parameter`, `unactuated_config`, `orphaned_file`, `unused_dependency`. These detectors must propose with cross-file reference data already in hand; today their LLM proposal step often runs file-local and then hopes verification will catch the FPs, which is the wrong order.
 - **File-tuple detectors** read the N files sharing a contract (typically a pair). Right window for contract gaps. Examples: `obligation_violation`, cross-file string drift, schema/ABI mismatch. `obligations.py` already groups by file pair; this becomes the pattern for all contract-gap detectors.
 
@@ -119,18 +119,28 @@ Detectors emit Findings with empty `verdict`/`confidence`/`reasoning`. Triage fi
 
 ### The Triage stage (B)
 
-One LLM-driven stage replaces the six+ scattered verification gates. Inputs: a batch of Findings with their gathered Evidence, plus shadow doc / facts context. Outputs: each Finding with verdict, confidence, reasoning, and suggested fix.
+One LLM-driven stage replaces the six+ scattered verification gates. Inputs: a batch of [self-sufficient claims](../concepts/self-sufficient-claims.md) — Findings whose Evidence has been mechanically assembled to be sufficient for one-shot reasoning. Outputs: each Finding with verdict, confidence, reasoning, and suggested fix.
 
 The Triage prompt is the single largest optimization target in the system. It encodes the three-gap rubric and instructs the model to weigh evidence kinds against the three TP predicates (reality, significance, actionability). The reasoning trace is captured verbatim — this is the "rich trace" gepa-style optimization needs in v2.
 
-### Evidence gathering
+The rubric explicitly distinguishes hard-coded-literal classes per [string-contract taxonomy](../concepts/string-contract-taxonomy.md): named project obligations get confirmed (with a "use the existing constant" suggested fix); unnamed project obligations get confirmed (with an "extract a shared constant" suggested fix); ecosystem conventions (HTTP codes, file modes, RFC-defined strings) get dismissed with reasoning; ambiguous magic-constant duplications get examined case-by-case; coincidental duplications get dismissed as coincidence. This is the LLM filter the current `obligations.py` lacks; routing all literal-based findings through Triage is what makes the rubric enforceable.
 
-Evidence appears at two distinct points and the Finding schema records both:
+When a claim arrives with the `insufficient_evidence` flag set (the Claim Builder couldn't fill required Evidence kinds), Triage escalates to exploration mode for that single claim — the LLM gets read/grep tool access and decides with retrieval. Cost stays bounded because the escalation rate is itself a tracked metric.
 
-- **Propose-time evidence** is whatever the detector consulted to *generate* the hypothesis (e.g., a project-graph detector cites the cross-file reference list it inspected; a file-pair detector cites both file contents). This is required input to the detector by its context-window class. Recording it makes the LLM's proposal auditable — Triage can see what the proposer saw.
-- **Triage-time evidence** is gathered after proposal by a single evidence-gathering pass that uses FactsDB, shadow docs, symbols, and (in v2) OSS scanner output to attach additional supporting data. This is where current per-detector verification logic gets centralized. `_verify_debris_findings_async` (`src/osoji/audit.py:262-399`) and the five+ analyzer-specific verify methods all collapse into one gathering pass + one Triage call.
+### Claim Builder
 
-Detectors don't gather their own *triage* evidence; they produce hypotheses with their propose-time context attached, the gathering pass adds the rest, Triage decides.
+Between detector and Triage there is one mechanical pass — the [Claim Builder](../concepts/self-sufficient-claims.md) — that assembles each Finding into a self-sufficient claim: the hypothesis, mechanically-gathered case-FOR evidence, mechanically-gathered case-AGAINST evidence, positional context (without semantic interpretation), and the relevant compressed-code substrate (shadow docs at file / directory / root scope as the gap-type warrants). Triage receives a batch of these claims and decides each in one LLM call, no exploration needed by default.
+
+Two sources feed the Claim Builder:
+
+- **Propose-time evidence** — whatever the detector consulted to generate the hypothesis (a project-graph detector cites the cross-file reference list it inspected; a file-pair detector cites both file contents). Recording it makes the LLM's proposal auditable.
+- **Builder-time evidence** — added by the Claim Builder pass: cross-file references from FactsDB, shadow doc content at appropriate scope, AGAINST-direction patterns (base class hierarchy for reachability, surrounding-code positional context for string contracts), and (in v2) OSS scanner output. This is where the current per-detector verification logic gets centralized. `_verify_debris_findings_async` (`src/osoji/audit.py:262-399`) and the five+ analyzer-specific verify methods all collapse into the Claim Builder + one Triage call per batch.
+
+The Claim Builder's evidence schema is a **configuration object**, not a hardcoded class — a list of evidence-kind-builders to invoke per claim. This keeps the schema mutable so v2 can apply gepa-style ablation: a Claim Builder mutation that drops an Evidence kind shouldn't hurt verdict accuracy if the kind was non-load-bearing.
+
+The Claim Builder's evidence schema is **bootstrapped from observation**, not stipulated. Step 3a in the [order of operations](#order-of-operations) below runs Triage in exploration mode against a representative test set, mines the LLM's tool-call traces for the Evidence kinds it consults, then mechanizes those kinds. Validate by ablation: rerun in claim-only mode and confirm verdicts match. This is the answer to "what evidence is sufficient?" — we measure rather than guess.
+
+When the Claim Builder cannot fill a required Evidence kind, it sets the `insufficient_evidence` flag on the claim and Triage escalates that single claim to exploration mode (see [Triage stage above](#the-triage-stage-b)).
 
 ### Tree-sitter substrate (E in earlier discussion)
 
@@ -149,6 +159,26 @@ The sweep skill (`src/osoji/skills/osoji-sweep.md`) gains a final phase that, in
 The user (or Claude in a follow-up session) reviews the auto-generated fixture and either accepts it (committing to the corpus) or rejects it (adjusting the sweep classification first). This converts the sweep workflow's existing output into corpus growth.
 
 The prompt-regression harness gets a new mode: `--evaluate` runs all fixtures and reports per-detector and overall TP/FP rates. This is the metric.
+
+## Epistemological note
+
+The "solid foundation" this rebuild aims for is layered, and being honest about which layer is which is part of what makes it solid. Four layers, with different revisability and different evidence requirements:
+
+| Layer | Examples in this spec | Revisable how |
+|---|---|---|
+| **Stipulated** | The TP-predicate definition (reality + significance + actionability) | Definitional choice. Defensible because it operationalizes "matters." Not derived from anything. Revisable only by re-defining what counts as a finding. |
+| **Taxonomic** | Three-gap theory; string-contract five-class rubric; Finding's `gap_type` and Evidence `kind` enums | Falsifiable engineering claims. Each closed-set taxonomy carries an `other`/`uncategorized` outlet. Revisable when the metrics below show the taxonomy is failing. |
+| **Engineering** | Claim Builder over exploration-mode; per-file/project-graph/file-tuple dispatch; shadow docs as primary compressed-code substrate; gepa as v2 optimizer target | Design choices supported by current evidence. Reversible at the [Finding schema](#the-finding-schema-a) boundary. Not provably optimal. Revisable when a measurement disagrees. |
+| **Measured** | Per-detector TP/FP rates; CE-gap and ME-overlap rates per taxonomy; escalation rate from Claim Builder; verdict-disagreement between claim-mode and exploration-mode in bootstrap | What we actually know. Outputs of the regression evaluator and the sweep-fixture corpus. Drives revisions to the layers above. |
+
+Two falsifiability metrics per closed-set taxonomy, applied differently by use:
+
+- **CE-gap rate** (proportion of items classified `other`/`uncategorized`) for taxonomies in *generative* use (frame what we're looking for). Rising rate signals a missing category.
+- **ME-overlap rate** (proportion of items legitimately fitting multiple categories that route to non-overlapping analysis) for taxonomies in *analytical* use (route to different pipelines). Structural overlap signals the dispatch boundary is wrong.
+
+Three-gap theory serves both uses, so it carries both metrics. The string-contract taxonomy is descriptive only (Triage rubric vocabulary), so only CE-gap matters. Detector context windows is dispatch only, so only ME-overlap matters.
+
+This framing is itself revisable — but the discipline behind it (no closed-set taxonomy without an `other` outlet and a metric on its adequacy) is the meta-principle the v1 architecture should not silently abandon.
 
 ## Repository layout
 
@@ -193,11 +223,12 @@ Architecture-first. Tree-sitter migration is a port, not a redesign — it's saf
 
 1. **Bootstrap session.** Create `osoji-wiki` repo. Implement MCP server (read/edit/write/delete/move/list with CAS). Bootstrap `wiki/` in osoji repo. Ingest this plan, the three-gap theory, the language-choice analysis, and the v1-scope decision as the first wiki entries. Wire `/brief` and `/debrief` skills. **Status: completed; see [specs/0002-wiki-bootstrap.md](0002-wiki-bootstrap.md).**
 2. **Finding schema + evidence model + detector context taxonomy.** Implement `findings.py` and `evidence.py`. Classify every existing detector into per-file / project-graph / file-tuple. No behavior change yet — existing detectors still emit their old shapes; an adapter converts to Findings. Ship this as a single PR; CI green.
-3. **Unified Triage stage.** Implement `triage.py`. Migrate Phase 3 debris verification to use it. Verify behavior is preserved on existing `prompt_regression` fixtures. PR.
-4. **Migrate detectors to their declared context windows.** This is where the FP-class the user has been fighting actually gets fixed. Reachability detectors (`deadcode`, `deadparam`, `plumbing`, `junk_orphan`, `junk_deps`) start consuming FactsDB at *propose* time, not just at filter/verify time — meaning their LLM proposal step sees cross-file references upfront. Contract detectors (`obligations` and any cross-file `latent_bug` cases) propose against file-tuple input. Per-file detectors (most `doc_analysis` paths, `stale_comment`, in-file `latent_bug`) keep their per-file shadow input unchanged. Per-analyzer verify methods deleted; Triage takes over. PR per analyzer or grouped, owner's choice.
-5. **Tree-sitter migration.** Python first; query outputs cross-validated against existing plugin snapshots. Then TypeScript. Then Go as the third language to prove the abstraction. PR per language.
-6. **Sweep → fixture corpus.** Add fixture-emitting phase to sweep skill. Add `--evaluate` mode to prompt-regression. Run sweep on osoji itself to seed the corpus.
-7. **Three-gap docs in wiki, dogfood evaluation.** Final concept pages. Run `--evaluate` and publish baseline TP/FP rates per detector.
+3. **Unified Triage stage (with both modes).** Implement `triage.py` supporting both exploration mode (LLM has tool access; used for bootstrap and escalation) and claim mode (LLM receives self-sufficient claims; default path). Migrate Phase 3 debris verification to claim mode with an initial-guess Claim Builder schema. Verify behavior is preserved on existing `prompt_regression` fixtures. PR.
+4. **Exploration-mode bootstrap and Claim Builder ablation.** Run Triage in exploration mode against a curated test set (existing `prompt_regression` fixtures plus a representative sample from the audit-osoji-on-osoji corpus). Log every tool call. Mine successful traces for the Evidence kinds the LLM consults. Mechanize those kinds in the Claim Builder. Ablate by rerunning in claim mode and measuring verdict-disagreement against the exploration baseline. Iterate until disagreement is below threshold. The output is the v1 Claim Builder schema, empirically derived. PR.
+5. **Migrate detectors to their declared context windows.** This is where the FP-class the user has been fighting actually gets fixed. Reachability detectors (`deadcode`, `deadparam`, `plumbing`, `junk_orphan`, `junk_deps`) start consuming FactsDB at *propose* time, not just at filter/verify time — meaning their LLM proposal step sees cross-file references upfront. Contract detectors (`obligations` and any cross-file `latent_bug` cases) propose against file-tuple input. Per-file detectors (most `doc_analysis` paths, `stale_comment`, in-file `latent_bug`) keep their per-file shadow input unchanged. Per-analyzer verify methods deleted; the Claim Builder + Triage take over. PR per analyzer or grouped, owner's choice.
+6. **Tree-sitter migration.** Python first; query outputs cross-validated against existing plugin snapshots. Then TypeScript. Then Go as the third language to prove the abstraction. PR per language.
+7. **Sweep → fixture corpus.** Add fixture-emitting phase to sweep skill. Add `--evaluate` mode to prompt-regression. Add CE-gap and ME-overlap rate tracking per taxonomy. Add Claim Builder escalation-rate tracking. Run sweep on osoji itself to seed the corpus.
+8. **Three-gap docs in wiki, dogfood evaluation.** Final concept pages. Run `--evaluate` and publish baseline TP/FP rates per detector along with taxonomy adequacy and escalation rates.
 
 Each step ships as a PR through the existing branch-protection workflow. CI must stay green throughout.
 
@@ -225,11 +256,13 @@ A v1 release ships when all of the following hold:
 
 1. **Existing prompt-regression fixtures all pass** at their established baselines, run through the new architecture. (Behavior preservation.)
 2. **New `--evaluate` mode** reports per-detector TP/FP rates on the seeded corpus. Initial corpus comes from one full sweep of osoji on osoji.
-3. **`osoji audit --full .` on the osoji repo** runs end-to-end through the unified architecture, finishes within 10% of current wall-clock time, and produces Findings with verdicts/confidence/reasoning populated.
-4. **Tree-sitter Python and TypeScript queries** produce symbol/fact outputs that match the deprecated plugins on a snapshot test. One additional language (Go) onboarded as a smoke test of the abstraction.
-5. **Wiki coverage**: every concept and decision in this plan exists as a wiki page, with cross-references and an updated index.
-6. **CLAUDE.md updated** to point at the wiki and brief/debrief workflow.
-7. **Detector context audit**: every detector documents its declared context-window class (per-file / project-graph / file-tuple) and does not read beyond it at propose time. Recorded in `wiki/detectors/<name>.md` for each detector.
+3. **Falsifiability metrics tracked**: CE-gap rate per taxonomy in generative use (notably `gap_type=uncategorized` rate, `string-class=other` rate); ME-overlap rate per taxonomy in analytical use; Claim Builder escalation rate. Each baselined.
+4. **`osoji audit --full .` on the osoji repo** runs end-to-end through the unified architecture, finishes within 10% of current wall-clock time, and produces Findings with verdicts/confidence/reasoning populated. Audit cost grows roughly linearly with finding count (claim-mode dominant; escalation as a small surcharge).
+5. **Claim Builder bootstrap converged**: verdict-disagreement between claim-mode and exploration-mode below threshold (e.g., 5%) on the bootstrap test set. The empirically-derived Evidence schema is checked in.
+6. **Tree-sitter Python and TypeScript queries** produce symbol/fact outputs that match the deprecated plugins on a snapshot test. One additional language (Go) onboarded as a smoke test of the abstraction.
+7. **Wiki coverage**: every concept and decision in this plan exists as a wiki page, with cross-references and an updated index.
+8. **CLAUDE.md updated** to point at the wiki, the brief/debrief workflow, and the closed-set-taxonomy-must-have-`other`-outlet meta-principle.
+9. **Detector context audit**: every detector documents its declared context-window class (per-file / project-graph / file-tuple) and does not read beyond it at propose time. Recorded in `wiki/detectors/<name>.md` for each detector.
 
 ## Out of scope for v1 (becomes v2/v3)
 
@@ -241,6 +274,9 @@ A v1 release ships when all of the following hold:
 
 ## Open questions deferred to session-level decisions
 
-- Exact wire format between detectors and the evidence-gathering pass (in-process call vs. typed bus). Resolve in step 2.
-- Whether sweep's auto-generated fixtures land in a holding directory pending review, or directly in `tests/fixtures/`. Resolve when implementing step 6.
+- Exact wire format between detectors and the Claim Builder pass (in-process call vs. typed bus). Resolve in step 2.
+- Whether sweep's auto-generated fixtures land in a holding directory pending review, or directly in `tests/fixtures/`. Resolve when implementing step 7.
+- Bootstrap test set composition for step 4: osoji-on-osoji only, or include sweeps from diverse projects? Probably a mix; resolve when the first bootstrap runs.
+- Whether the Claim Builder schema is serialized as Python config (a list of evidence-kind callables) or as a separate config format (YAML/JSON). The latter is friendlier to gepa-style mutation in v2; the former is simpler in v1. Resolve in step 3.
+- Per-Evidence-kind weighting: keep the `weight_hint` field, or remove it and let the LLM weight implicitly? Defer until the bootstrap measures whether weights move verdicts.
 - ~~Whether the brief/debrief sub-agents use the MCP server's prompt resources or are reimplemented in skill markdown.~~ **Resolved in [specs/0002-wiki-bootstrap.md](0002-wiki-bootstrap.md): skills only, no MCP prompts in v1.**


### PR DESCRIPTION
## Summary

Three architectural refinements emerged from a follow-up brainstorming session on the v1 plan. All three sharpen the foundation for the v1 rebuild without changing the agreed scope.

### What changes

**1. Description gaps now have a scope spectrum.** A comment can drift relative to its adjacent code, its directory's pattern, or the project's architecture. The minimum-context invariant for description gaps changes from "per-file context" to "smallest sufficient shadow scope" — using osoji's existing three-tier shadow doc layout (\`<file>.shadow.md\`, \`_directory.shadow.md\`, \`_root.shadow.md\`) as the substrate. \`wiki/concepts/three-gap-theory.md\` updated.

**2. New string-contract taxonomy** (\`wiki/concepts/string-contract-taxonomy.md\`). Hard-coded literals fall into five distinct classes: named project obligation, unnamed project obligation, ecosystem convention (HTTP codes, RFC values), magic-constant duplication (ambiguous), and coincidence. The current \`obligations.py\` pure-rule check conflates these; routing through Triage with the new rubric is the structural fix for the FP class. The taxonomy is descriptive (Triage rubric vocabulary), not detector logic.

**3. New Claim Builder concept** (\`wiki/concepts/self-sufficient-claims.md\`). Triage shouldn't explore — it should reason. The Claim Builder mechanically assembles self-sufficient claims (case-FOR, case-AGAINST, positional context, shadow-doc-primary substrate) so Triage decides each in one LLM call. Bounded token cost. Bootstrapped from observation: run Triage in exploration mode, mine the LLM's tool calls, mechanize discovered Evidence kinds, ablate. Designed-for gepa optimization in v2. Falls back to exploration when claims flag insufficient evidence.

### Foundation framing (\`Epistemological Note\` section in v1 spec)

The v1 spec gains an explicit four-layer foundation: **stipulated** (TP-predicate definition), **taxonomic** (three-gap, string-contract, evidence kinds — falsifiable engineering claims), **engineering** (Claim Builder, dispatch rules, gepa as v2 target), **measured** (per-detector TP/FP, taxonomy adequacy rates, escalation rate).

Two falsifiability metrics per closed-set taxonomy:
- **CE-gap rate** (\`other\`-outlet usage) for generative-use taxonomies
- **ME-overlap rate** for analytical-use taxonomies

Three-gap theory serves both uses → both metrics. String-contract is descriptive only → CE-gap only. Detector context windows is dispatch only → ME-overlap only.

### Order of operations

A new step 4 — Exploration-mode bootstrap and Claim Builder ablation — sits between Triage stage (step 3) and detector migration (step 5). This is what produces the empirically-derived Evidence schema.

### CLAUDE.md additions

Two new pipeline-engineering principles:
- Closed-set taxonomies require an \`other\` outlet, and \`other\`-rate is itself a metric.
- Mechanical layers gather; LLM layers reason; both are answerable to the regression evaluator. The boundary is empirical, not rule-based.

### Files changed

- \`CLAUDE.md\` — two new principles
- \`wiki/concepts/three-gap-theory.md\` — \`uncategorized\` outlet, scope spectrum, falsifiability framing
- \`wiki/concepts/string-contract-taxonomy.md\` — new
- \`wiki/concepts/self-sufficient-claims.md\` — new
- \`wiki/specs/0001-v1-foundation.md\` — Claim Builder replaces ad-hoc Evidence Gathering; Epistemological Note added; step 4 inserted; Verification gains escalation/falsifiability/bootstrap criteria
- \`wiki/index.md\` — two new concept entries
- \`wiki/log.md\` — entries for each change

### Note on workflow

This session edited the wiki via direct file writes rather than the \`osoji-wiki\` MCP server, because newly-registered MCP servers don't surface their tools until Claude Code restarts. Single-agent edits don't need CAS; future sessions with the MCP loaded will use \`/debrief\` and the \`wiki_edit\` CAS path normally.

## Test plan

- [x] All seven changed/new pages have valid frontmatter per \`wiki/SCHEMA.md\`
- [x] Cross-references between concepts and the v1 spec resolve
- [x] Order of operations references in concept pages match the renumbered steps
- [x] Step renumbering (4→5, 5→6, 6→7, 7→8) consistently applied
- [ ] CI green on this branch
- [ ] Reviewer confirms the four-layer epistemological framing reads as solid foundation, not as hedging

🤖 Generated with [Claude Code](https://claude.com/claude-code)