### PR TITLE
wiki debrief: plugin packaging decision (0003)

### DIFF
--- a/wiki/decisions/0003-plugin-packaging.md
+++ b/wiki/decisions/0003-plugin-packaging.md
@@ -1,0 +1,56 @@
+---
+id: "0003"
+title: Distribute osoji-wiki as a Claude Code plugin
+type: decision
+status: accepted
+created: 2026-04-29
+updated: 2026-04-29
+related: [specs/0002-wiki-bootstrap.md]
+---
+
+## Context
+
+The wiki bootstrap (spec 0002) shipped osoji-wiki as a normal Python package: contributors ran `pip install -e ".[dev]"`, registered the MCP server with `claude mcp add`, and copied the brief/debrief skill files into `~/.claude/skills/`. None of that state was version-controlled. A machine move broke the workflow; updating the server required manual re-registration; the skills got out of sync if the user edited one copy.
+
+## Decision
+
+Ship osoji-wiki as a Claude Code plugin. The repository is both the marketplace and the plugin (`.claude-plugin/marketplace.json` lists a single plugin at `source: "./"`). End-user install is two commands inside Claude Code:
+
+```
+/plugin marketplace add osojicode/osoji-wiki
+/plugin install osoji-wiki@osojicode
+```
+
+The installer prompts for `wiki_root` (a `userConfig` field of type `directory`) and persists the value in `settings.json` under `pluginConfigs["osoji-wiki@osojicode"].options`. A `SessionStart` hook creates a private venv under `${CLAUDE_PLUGIN_DATA}/venv` and `pip install`s `mcp`, `click`, `pyyaml` into it on first use; subsequent sessions reuse it. The MCP server is auto-registered. Skills are namespaced as `/osoji-wiki:brief` and `/osoji-wiki:debrief`.
+
+## Sub-decisions
+
+| Question | Choice | Why |
+|---|---|---|
+| Skill layout | `skills/<name>/SKILL.md` (subdir) | Required by plugin spec; flat `skills/<name>.md` is rejected |
+| Cross-platform setup | Python launcher scripts (`scripts/install.py`, `scripts/run.py`) | `plugin.json` is static JSON — no OS-conditional values. Python handles `Scripts/python.exe` vs `bin/python` via `sys.platform` |
+| Venv location | `${CLAUDE_PLUGIN_DATA}/venv` | Survives plugin updates; `${CLAUDE_PLUGIN_ROOT}` does not |
+| Plugin source install | `PYTHONPATH=${CLAUDE_PLUGIN_ROOT}/src` in launcher | Avoids `pip install -e` of plugin source; only third-party deps go in venv |
+| Setup idempotence | Marker file `${CLAUDE_PLUGIN_DATA}/.installed-version` = SHA-256 of `requirements.txt` | Hook runs every session start; no-op when marker matches |
+| Marketplace name | `osojicode` (the org) | Canonical install command becomes `osoji-wiki@osojicode` instead of awkward `osoji-wiki@osoji-wiki` |
+
+## Alternatives considered
+
+- **Bash-based SessionStart hook** with platform detection. Rejected: Git Bash on Windows is not guaranteed; Python is already required for the server itself.
+- **Wrapper Python script that's the MCP `command` directly** (no venv). Rejected: pollutes the user's system Python with plugin deps.
+- **Bundle the plugin's own source into the venv via `pip install -e ${CLAUDE_PLUGIN_ROOT}`**. Rejected: `${CLAUDE_PLUGIN_ROOT}` changes on plugin updates, leaving the venv pointing at a stale path. PYTHONPATH manipulation is simpler and survives updates because the launcher resolves the current root each invocation.
+- **Symlinks for the brief/debrief skills**. Rejected upstream of the plugin work: Git Bash on Windows fell back to copies without Developer Mode.
+
+## Consequences
+
+- Slash commands change: `/brief` and `/debrief` are now `/osoji-wiki:brief` and `/osoji-wiki:debrief`. Plugin skills are always namespaced.
+- The previously registered MCP server (project-scoped, pointing at a local `.venv`) and the user-level skill copies (`~/.claude/skills/{brief,debrief}.md`) must be removed once on each machine that had the manual install.
+- Plugin updates land via `/plugin update osoji-wiki@osojicode` — no per-machine work required.
+- A fresh machine needs only Python 3.11+ on PATH plus the two install commands; everything else is automatic.
+
+## Sources
+
+- Claude Code plugins overview: https://code.claude.com/docs/en/plugins.md
+- Plugin manifest reference: https://code.claude.com/docs/en/plugins-reference.md
+- Plugin discovery and install: https://code.claude.com/docs/en/discover-plugins.md
+- Plugin marketplaces: https://code.claude.com/docs/en/plugin-marketplaces.md

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,6 +18,7 @@ Tooling: [`osoji-wiki`](https://github.com/osojicode/osoji-wiki) — MCP server 
 ## Decisions
 
 - [0002 — Language choice: Python (with a sidecar door open)](decisions/0002-language-choice.md) — why osoji stays in Python for v1.
+- [0003 — Distribute osoji-wiki as a Claude Code plugin](decisions/0003-plugin-packaging.md) — supersedes the manual install workflow from spec 0002 with `/plugin install osoji-wiki@osojicode`.
 
 ## Detectors
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -19,3 +19,6 @@ Append-only changelog of wiki edits. Format: `YYYY-MM-DD <op> <path> — <one-li
 2026-04-29 edit specs/0001-v1-foundation.md — Claim Builder replaces ad-hoc evidence gathering; new step 4 (exploration-mode bootstrap and ablation); add Epistemological Note section with four-layer foundation (stipulated/taxonomic/engineering/measured); Verification gains escalation-rate, falsifiability-metrics, and bootstrap-convergence criteria
 2026-04-29 edit index.md — add string-contract-taxonomy and self-sufficient-claims entries; update detector section reference (step 4 → 5)
 2026-04-29 edit ../CLAUDE.md — add closed-set-taxonomies-need-`other` and mechanical-vs-LLM-boundary-decided-by-measurement to pipeline engineering principles
+2026-04-29 write decisions/0003-plugin-packaging.md — record plugin packaging decision; supersedes manual install from spec 0002
+2026-04-29 edit specs/0002-wiki-bootstrap.md — note install workflow superseded by decision 0003
+2026-04-29 edit index.md — add decision 0003 entry

--- a/wiki/specs/0002-wiki-bootstrap.md
+++ b/wiki/specs/0002-wiki-bootstrap.md
@@ -5,8 +5,10 @@ type: spec
 status: accepted
 created: 2026-04-29
 updated: 2026-04-29
-related: [specs/0001-v1-foundation.md, decisions/0002-language-choice.md, concepts/three-gap-theory.md]
+related: [specs/0001-v1-foundation.md, decisions/0002-language-choice.md, decisions/0003-plugin-packaging.md, concepts/three-gap-theory.md]
 ---
+
+> **Update (2026-04-29):** the install workflow described below — `pip install -e`, `claude mcp add`, manual skill-file copy — has been replaced by Claude Code plugin distribution. See [decisions/0003-plugin-packaging.md](../decisions/0003-plugin-packaging.md). The seed content captured here is unchanged; only how the tooling reaches a developer's machine has moved on.
 
 ## Context
 
@@ -98,7 +100,7 @@ osoji/wiki/
 
 ## Out of scope (deferred)
 
-- Installing the brief/debrief skills into Claude Code's skill directory (`~/.claude/skills/`) or registering the MCP server in Claude Code settings — left to the user to do explicitly.
+- Installing the brief/debrief skills into Claude Code's skill directory or registering the MCP server in Claude Code settings — handled in a follow-up by [decisions/0003-plugin-packaging.md](../decisions/0003-plugin-packaging.md), not in this bootstrap session.
 - Multi-process / multi-host wiki MCP semantics; single-host single-process is sufficient for v1.
 - Auto-PR of the osoji `wiki/` bootstrap; the branch is pushed but the PR is opened by the user (or as a separate confirmed action).
 
@@ -107,4 +109,4 @@ osoji/wiki/
 1. **GitHub org for the new repo:** `osojicode` (matches `osojicode/osoji`). Repo: `git@github.com:osojicode/osoji-wiki.git`, private.
 2. **Scope of the bootstrap session:** Tooling **and** content seed — both the `osoji-wiki` repo and this `wiki/` bootstrap.
 3. **brief/debrief surface:** Skills only — markdown files in `osoji-wiki/skills/`, no MCP prompts.
-4. **MCP server registration in Claude Code settings:** Out of scope for this session.
+4. **MCP server registration in Claude Code settings:** Out of scope for this session; superseded by [decisions/0003-plugin-packaging.md](../decisions/0003-plugin-packaging.md).


### PR DESCRIPTION
## Summary

- Add `wiki/decisions/0003-plugin-packaging.md` — ADR capturing the choice to ship osoji-wiki as a Claude Code plugin (rationale, sub-decisions, alternatives, consequences, source citations to the four official Claude Code plugin docs pages).
- Bump `wiki/specs/0002-wiki-bootstrap.md` with an inline note that the install workflow it described has been superseded by decision 0003. The seed content captured by that spec is unchanged.
- Update `wiki/index.md` and `wiki/log.md` accordingly.

## Companion to

- osoji-wiki [PR #1](https://github.com/osojicode/osoji-wiki/pull/1) — the plugin packaging itself
- osoji [PR #69](https://github.com/osojicode/osoji/pull/69) — `.claude/skills/` mirror + CLAUDE.md namespace update

## Bug surfaced (follow-up needed in osoji-wiki)

`wiki_read` on any page with unquoted ISO dates in YAML frontmatter fails with `"Object of type date is not JSON serializable"`. The YAML loader returns `datetime.date`; the server's JSON serialization can't handle it. Repro: `wiki_read("specs/0002-wiki-bootstrap.md")`. Currently blocks `/debrief` from updating most existing pages — I worked around it for this PR by editing the affected pages directly on disk, but a small fix in osoji-wiki's `frontmatter.py` (coerce dates to ISO strings before returning) is warranted.

## Test plan

- [x] All four edits applied: 1 new file, 3 modified
- [x] `wiki_edit` calls for index.md and log.md returned successful hashes via the new plugin's MCP server (also serves as live verification of the plugin migration)
- [ ] After merge: `wiki_list("decisions/")` shows the new entry; `wiki_read("decisions/0003-plugin-packaging.md")` returns body+hash cleanly (this page uses unquoted dates and will trigger the bug above until osoji-wiki ships a fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)