### PR TITLE
fix(deps): bump urllib3 to 2.7.0 to clear CVE-2026-44431/44432

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -952,9 +952,9 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via pydantic
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 websockets==16.0 \
     --hash=sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c \

--- a/requirements-tools.lock
+++ b/requirements-tools.lock
@@ -357,9 +357,9 @@ tomli-w==1.2.0 \
     --hash=sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90 \
     --hash=sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021
     # via pip-audit
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 uv==0.11.8 \
     --hash=sha256:0172b5215544844cd3db0fa3c73a2eb74999b3f00cd2527dde578725076d7b65 \

--- a/requirements.lock
+++ b/requirements.lock
@@ -637,9 +637,9 @@ typing-inspection==0.4.2 \
     --hash=sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7 \
     --hash=sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464
     # via pydantic
-urllib3==2.6.3 \
-    --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
-    --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via requests
 websockets==16.0 \
     --hash=sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c \


### PR DESCRIPTION
## Summary
- `pip-audit -r requirements.lock` has been failing the `audit` CI job on every open PR (and on main itself) due to two CVEs against transitive `urllib3 2.6.3` (pulled in via `requests`).
- Regenerated all three lock files with `uv pip compile … --upgrade-package urllib3`. Only `urllib3` pin + hashes changed — nothing else moved.
- This unblocks the four currently-open Dependabot PRs (#75, #77, #78, #79).

## CVEs cleared
- CVE-2026-44431 (urllib3, fixed in 2.7.0)
- CVE-2026-44432 (urllib3, fixed in 2.7.0)

## Test plan
- [x] Local: `pip-audit -r requirements.lock` → "No known vulnerabilities found"
- [ ] CI: all four lockfile-aware jobs (`test 3.11/3.12/3.13`, `audit`) pass
- [ ] After merge: rebase / re-run `audit` on #75, #77, #78, #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)