### PR TITLE
V1-5a follow-up: sweep corpus honesty (walker-based scan_files + truncation veto)

### DIFF
--- a/src/osoji/deadcode.py
+++ b/src/osoji/deadcode.py
@@ -639,14 +639,19 @@ async def detect_dead_code_async(
 
 def _clean_zero_reference(claim: Claim) -> bool:
     """True iff the built evidence shows an honest zero — no graph or textual
-    references over a non-empty sweep. Anything else (any hit, or a sweep that
-    could not run) is Triage's call, not a mechanical proof."""
+    references over a non-empty, non-truncated sweep. Anything else (any hit,
+    a sweep that could not run, or a corpus cut off at its cap) is Triage's
+    call, not a mechanical proof."""
 
     for ev in claim.finding.evidence:
         if ev.kind == "cross_file_reference":
             refs = ev.payload.get("references") or []
             scope = ev.payload.get("scan_scope") or {}
-            return not refs and scope.get("files_scanned", 0) > 0
+            return (
+                not refs
+                and scope.get("files_scanned", 0) > 0
+                and not scope.get("truncated")
+            )
     return False
 
 

--- a/src/osoji/evidence_builders.py
+++ b/src/osoji/evidence_builders.py
@@ -71,6 +71,7 @@ class BuildContext:
     symbols_by_file: dict[str, list[dict]] | None = None
     _file_cache: dict[str, list[str] | None] = field(default_factory=dict, repr=False)
     _scan_files: list[str] | None = field(default=None, repr=False)
+    _scan_truncated: bool = field(default=False, repr=False)
 
     def facts(self) -> Any:
         if self.facts_db is None:
@@ -101,25 +102,49 @@ class BuildContext:
         return self._file_cache[key]
 
     def scan_files(self) -> list[str]:
-        """Root-relative POSIX paths of the text-scan corpus (cached)."""
+        """Root-relative POSIX paths of the text-scan corpus (cached).
+
+        The corpus is the walker's repo view (git-tracked / ignore-filtered),
+        NOT a raw directory glob. A raw glob dilutes the sweep with
+        git-ignored build outputs and vendored trees, and once the cap bites,
+        truncation is corpus pollution with the sign flipped: on
+        mcp-debugger (12k glob entries vs 822 repo files) the flagged file
+        itself fell outside the capped corpus and a "zero matches" sweep
+        mechanically confirmed a symbol that its own file uses four times.
+        The skip-dir filter is kept for the walker's non-git rglob fallback.
+        """
 
         if self._scan_files is None:
+            from .walker import list_repo_files
+
             files: list[str] = []
             root = self.config.root_path
             try:
-                for path in root.glob("**/*"):
-                    if not path.is_file():
+                paths, _used_git = list_repo_files(self.config)
+                for path in paths:
+                    full = path if path.is_absolute() else root / path
+                    if not full.is_file():
                         continue
-                    rel = path.relative_to(root)
+                    rel = full.relative_to(root)
                     if any(part in _SKIP_DIRS for part in rel.parts):
                         continue
-                    files.append(rel.as_posix())
                     if len(files) >= _MAX_SCAN_FILES:
+                        # Cap reached with corpus remaining: record the
+                        # truncation so downstream consumers can refuse to
+                        # treat a zero-hit sweep as evidence-of-absence.
+                        self._scan_truncated = True
                         break
+                    files.append(rel.as_posix())
             except OSError:
                 pass
             self._scan_files = files
         return self._scan_files
+
+    def scan_truncated(self) -> bool:
+        """True iff the last :meth:`scan_files` corpus hit the size cap."""
+
+        self.scan_files()
+        return self._scan_truncated
 
 
 # --- shared positional helpers (relocated verbatim from claim_builder V1-3) --
@@ -473,6 +498,10 @@ class CrossFileReferenceBuilder(EvidenceBuilder):
         for p in _named_paths(finding, ctx):
             if p not in named:
                 named.append(p)
+        # The flagged file is minimum context — sweep it regardless of
+        # whether the (possibly capped) corpus reached it.
+        if source not in named and ctx.read_lines(source) is not None:
+            named.append(source)
         extensions = getattr(ctx.config, "extensions", ())
         source_parts = PurePosixPath(source).parts
 
@@ -563,6 +592,9 @@ class CrossFileReferenceBuilder(EvidenceBuilder):
             "needle_totals": needle_totals,
             "same_file_swept": True,
         }
+        if ctx.scan_truncated():
+            # A capped corpus cannot support evidence-of-absence claims.
+            scan_scope["truncated"] = True
         if not references and not export_surface and not ordered:
             # We could not even look — no graph, no corpus. This (and only
             # this) is the insufficient-evidence case for references.

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -528,6 +528,11 @@ def _render_evidence(ev: Evidence) -> str:
                 f"No references found: {scope.get('files_scanned')} files swept "
                 f"for {', '.join(scope.get('needles', []))} — zero matches, {swept}."
             )
+            if scope.get("truncated"):
+                out.append(
+                    "CAUTION: the scan corpus was TRUNCATED at its size cap — "
+                    "this zero is not evidence-of-absence for the whole repository."
+                )
         surface = ev.payload.get("export_surface")
         if surface:
             exported = "IS" if surface.get("exported_from_flagged_file") else "is NOT"

--- a/tests/fixtures/bootstrap/ab-v15a-report.md
+++ b/tests/fixtures/bootstrap/ab-v15a-report.md
@@ -65,3 +65,27 @@ its own reasoning.
 
 Raw audit JSONs (side A, side B initial + final) retained locally; bootstrap corpus
 re-check traces committed under `traces/claim-v15a/`.
+
+## Addendum: first out-of-distribution run (mcp-debugger, 2026-07-04)
+
+Day-zero run on `osojicode/mcp-debugger` (public, TypeScript-dominant: 341 `.ts` + 26
+`.py`, no prior `.osoji`), claude-code provider: shadow generation for 489 source files,
+then `--dead-code --dead-params` through the unified pipeline.
+
+**It caught a corpus-honesty bug invisible in-distribution.** `BuildContext.scan_files`
+globbed the working tree raw: mcp-debugger's checked-out `dist/`, `dist-tarball/`,
+`coverage/` and friends made 12,219 glob entries vs 822 repo files, the
+`_MAX_SCAN_FILES=5000` cap truncated in glob order, and the flagged file itself fell
+outside the corpus — so a "zero matches" sweep mechanically confirmed
+`SWAP_SCRIPT_PATH`, a constant its own file uses four times. Fixed (commit `75f8a2a`):
+walker-based corpus (git-tracked/ignore-filtered), flagged file always swept,
+truncation flagged in `scan_scope`, rendered as a caution, and vetoing mechanical
+confirms. The raw glob had a second failure direction the fix also closes: stale build
+artifacts vouching for deleted source symbols.
+
+**Corrected result: 50 candidates proposed (12 AST-demoted + 12 grep + 26 params),
+0 confirmed.** Hand adjudication of a dismissal sample agrees: the zero-ref symbols are
+example-script locals, same-file subclass anchors (`LanguageRuntimeNotFoundError` →
+`PythonNotFoundError`), injectable same-file defaults (`listTaggedJvms`), and MCP tool
+parameters passed dynamically from protocol dispatch (`args.includeInternals ?? false`)
+— a well-kept repo, correctly reported as such. ~22.5K output tokens for the audit.

--- a/tests/test_evidence_builders.py
+++ b/tests/test_evidence_builders.py
@@ -555,3 +555,55 @@ def test_sweep_orders_by_proximity_to_flagged_file(config, temp_dir):
     evidence = BUILDERS["cross_file_reference"].build(finding, ctx)
     files = [r["file"] for r in evidence[0].payload["references"]]
     assert files[0] == "src/pkg/impl.py"
+
+
+def test_scan_corpus_uses_walker_and_skips_osoji_artifacts(config, temp_dir):
+    write(temp_dir, "src/x.py", "code\n")
+    write(temp_dir, ".osoji/shadow/src/x.py.shadow.md", "shadow\n")
+    ctx = BuildContext(config)
+    files = ctx.scan_files()
+    assert "src/x.py" in files
+    assert not any(f.startswith(".osoji") for f in files)
+    assert ctx.scan_truncated() is False
+
+
+def test_truncated_corpus_is_flagged_and_flagged_file_still_swept(config, temp_dir, monkeypatch):
+    # mcp-debugger lesson: a capped corpus silently excluded the flagged file,
+    # turning four same-file usages into a "zero matches" mechanical confirm.
+    import osoji.evidence_builders as eb
+
+    for i in range(6):
+        write(temp_dir, f"src/a_{i}.py", "filler\n")
+    write(temp_dir, "src/zz_flagged.py",
+          "def old_helper():\n    pass\n\nold_helper()\n")
+    monkeypatch.setattr(eb, "_MAX_SCAN_FILES", 3)
+    finding = make_finding(path="src/zz_flagged.py", line_start=1, line_end=2)
+    ctx = BuildContext(config, facts_db=FakeFacts(), symbols_by_file={})
+    evidence = BUILDERS["cross_file_reference"].build(finding, ctx)
+    payload = evidence[0].payload
+    assert payload["scan_scope"].get("truncated") is True
+    # The same-file usage at L4 was found even though the corpus cap
+    # excluded src/zz_flagged.py from the walked corpus.
+    same_file = [r for r in payload["references"] if r.get("same_file")]
+    assert same_file and same_file[0]["line"] == 4
+
+
+def test_truncated_zero_sweep_is_not_a_mechanical_proof(config, temp_dir, monkeypatch):
+    from osoji.deadcode import _clean_zero_reference
+    from osoji.triage import Claim
+    import osoji.evidence_builders as eb
+
+    for i in range(6):
+        write(temp_dir, f"src/a_{i}.py", "filler\n")
+    write(temp_dir, "src/zz_flagged.py", "def lonely():\n    pass\n")
+    monkeypatch.setattr(eb, "_MAX_SCAN_FILES", 3)
+    finding = make_finding(
+        path="src/zz_flagged.py", symbol="lonely", line_start=1, line_end=2
+    )
+    ctx = BuildContext(config, facts_db=FakeFacts(), symbols_by_file={})
+    [ev] = BUILDERS["cross_file_reference"].build(finding, ctx)
+    claim = Claim(finding=make_finding(
+        path="src/zz_flagged.py", symbol="lonely", line_start=1, line_end=2,
+        evidence=[ev],
+    ))
+    assert _clean_zero_reference(claim) is False


### PR DESCRIPTION
## Summary

Follow-up to #111 (merged before these commits landed on its branch). The first **out-of-distribution run** of the migrated pipeline — day-zero on osojicode/mcp-debugger (TypeScript-dominant, 341 `.ts` files, no prior `.osoji`) — caught a corpus-honesty bug that osoji-on-osoji could never surface.

## The bug

`BuildContext.scan_files` globbed the working tree raw. mcp-debugger's checked-out build artifacts (`dist/`, `dist-tarball/`, `coverage/`) made **12,219 glob entries vs 822 repo files**; the `_MAX_SCAN_FILES=5000` cap truncated in glob order and the flagged file itself fell outside the swept corpus. A "zero matches over 5,000 files" sweep then became a *dishonest* evidence-of-absence, and the AST mechanical-confirm path shipped a false positive at confidence 1.0 (`SWAP_SCRIPT_PATH` — a constant used four times in its own file). The raw glob also had the inverse failure mode: stale build artifacts can vouch for symbols deleted from source.

## The fix

- `scan_files` walks the repo via `walker.list_repo_files` (git-tracked / ignore-filtered — the same honest corpus every other pipeline layer uses; skip-dir filter kept for the non-git rglob fallback)
- the flagged file is always swept (minimum context), cap or no cap
- truncation is recorded in `scan_scope`, rendered to the LLM as an explicit caution, and **vetoes mechanical confirms** (`_clean_zero_reference` refuses a truncated zero)

## Verification

- Deterministic suite: 1058 passed (3 new corpus-honesty tests).
- mcp-debugger re-run after the fix: 50 candidates proposed, **0 confirmed** — `SWAP_SCRIPT_PATH` demoted and dismissed; a hand-adjudicated sample of dismissals (same-file subclass anchors, injectable defaults, MCP protocol-dispatched parameters) all correct. Full narrative in the committed `tests/fixtures/bootstrap/ab-v15a-report.md` addendum.
- Wiki decision 0016 updated (decision 3): every evidence-of-absence producer must state — and consumers must check — the honesty of its scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)