### PR TITLE
Reconfigure stdout/stderr to UTF-8 in CLI entry point

### DIFF
--- a/src/osoji/cli.py
+++ b/src/osoji/cli.py
@@ -1,6 +1,7 @@
 """Click CLI for Osoji."""
 
 import asyncio
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -55,6 +56,23 @@ def _build_llm_config(
     )
 
 
+def _configure_utf8_output() -> None:
+    """Reconfigure stdout/stderr to UTF-8 with replacement fallback.
+
+    Findings contain arbitrary LLM-generated Unicode; report printing must not
+    assume the console locale (e.g. Windows cp1252) can represent it.
+    """
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            continue
+
+
 def _cli_state(ctx: click.Context) -> CLIState:
     """Return the inherited CLI state for the current command."""
 
@@ -82,6 +100,7 @@ def main(ctx: click.Context, verbose: bool, quiet: bool) -> None:
     Audit your project for dead code, stale documentation, and semantic
     contradictions. Ships with agent skill files for automated triage and fixing.
     """
+    _configure_utf8_output()
     load_dotenv()  # Load .env before any subcommand (does not override existing env vars)
     if verbose and quiet:
         raise click.UsageError("Cannot use --verbose and --quiet together.")

--- a/tests/test_cli_output_encoding.py
+++ b/tests/test_cli_output_encoding.py
@@ -1,0 +1,58 @@
+"""Tests for UTF-8 console output configuration.
+
+Findings contain arbitrary LLM-generated Unicode; report printing must not
+assume the console locale can represent it. On Windows cp1252 consoles,
+printing a finding containing characters like '→' crashed with
+UnicodeEncodeError after the audit itself had already succeeded.
+"""
+
+import io
+import sys
+
+from click.testing import CliRunner
+
+import osoji.cli
+from osoji.cli import _configure_utf8_output, main
+
+
+def _cp1252_stream() -> io.TextIOWrapper:
+    return io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+
+
+def test_cp1252_stdout_prints_non_ascii_without_error(monkeypatch):
+    monkeypatch.setattr(sys, "stdout", _cp1252_stream())
+    monkeypatch.setattr(sys, "stderr", _cp1252_stream())
+
+    _configure_utf8_output()
+
+    # '→' has no cp1252 encoding; without reconfiguration this raises
+    # UnicodeEncodeError.
+    print("dead_symbol → removed", file=sys.stdout)
+    print("warning → detail", file=sys.stderr)
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    assert "→".encode("utf-8") in sys.stdout.buffer.getvalue()
+    assert "→".encode("utf-8") in sys.stderr.buffer.getvalue()
+
+
+def test_stream_without_reconfigure_is_tolerated(monkeypatch):
+    # io.StringIO has no reconfigure(); the helper must degrade gracefully
+    # rather than crash on exotic stream replacements.
+    monkeypatch.setattr(sys, "stdout", io.StringIO())
+    monkeypatch.setattr(sys, "stderr", io.StringIO())
+
+    _configure_utf8_output()
+
+    print("plain", file=sys.stdout)
+
+
+def test_main_callback_configures_output(monkeypatch):
+    calls = []
+    monkeypatch.setattr(osoji.cli, "_configure_utf8_output", lambda: calls.append(True))
+    runner = CliRunner()
+
+    result = runner.invoke(main, ["skills", "list"])
+
+    assert result.exit_code == 0
+    assert calls, "main() group callback must configure output encoding"


### PR DESCRIPTION
## Summary

Fixes the Windows cp1252 console crash from osojicode/work#49: `osoji audit` completed all LLM phases and persisted results, then died with `UnicodeEncodeError` while printing a finding containing '→'.

- New `_configure_utf8_output()` in `src/osoji/cli.py`: reconfigures `sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"`, called from the `main` group callback so every subcommand is covered.
- Degrades gracefully on streams without `reconfigure()` (exotic stream replacements, captured test streams).
- Fix is at the I/O layer — no assumptions about finding content (language-agnostic).

## Tests

`tests/test_cli_output_encoding.py` (TDD, watched fail first):
- cp1252-wrapped stdout/stderr print '→' without error and emit UTF-8 bytes
- streams lacking `reconfigure()` are tolerated
- the `main` callback actually invokes the helper

Full suite: 1101 passed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)