### PR TITLE
Fix four doc drifts found by the V1-5d A/B

### DIFF
--- a/.claude/skills/osoji-sweep/SKILL.md
+++ b/.claude/skills/osoji-sweep/SKILL.md
@@ -129,7 +129,8 @@ about to happen:
 > Uploading audit results to your configured osoji-teams endpoint at ENDPOINT_URL…
 
 To resolve the endpoint for the message, read it from (in priority order):
-`OSOJI_ENDPOINT` env var, `.osoji.toml` `[push].endpoint`, or
+`OSOJI_ENDPOINT` env var, `.osoji.local.toml` `[push].endpoint`,
+`.osoji.toml` `[push].endpoint`, or
 `~/.config/osoji/config.toml` `[push].endpoint`.
 
 Then run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- LLM providers migrated from LiteLLM to direct SDKs (`anthropic`, `openai`,
+  `google-genai`, OpenRouter via the OpenAI SDK); the 0.2.0 "all via LiteLLM"
+  note below describes that release, not the current implementation
+
 ## [0.2.0] - 2026-03-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ export analysis, and string contract checking.
 - `src/osoji/config.py` — Configuration, path helpers, model tier constants
 - `src/osoji/shadow.py` — Core shadow doc generation engine
 - `src/osoji/audit.py` — Multi-phase audit orchestration
-- `src/osoji/llm/` — LLM provider abstraction (Anthropic, OpenAI, Google, OpenRouter via LiteLLM; Claude Code via CLI), validation, token counting
+- `src/osoji/llm/` — LLM provider abstraction (Anthropic, OpenAI, Google, OpenRouter via direct SDKs; Claude Code via CLI), validation, token counting
 - `src/osoji/rate_limiter.py` — Reservation-based async rate limiter (RPM + input/output TPM)
 - `src/osoji/facts.py` — Structured facts database and queries
 - `src/osoji/symbols.py` — Symbol loading and querying from `.osoji/symbols/`

--- a/SUPPLY-CHAIN-SECURITY.md
+++ b/SUPPLY-CHAIN-SECURITY.md
@@ -110,9 +110,17 @@ PR is worth engaging with.
 
 ### Pre-commit safety
 
-The `osoji safety check` pre-commit hook blocks commits containing:
-- Personal filesystem paths (e.g. `/Users/jsmith/`, `C:\Users\`)
-- Secrets and API keys (via detect-secrets)
+The pre-commit hook installed by `osoji hooks install` runs two steps:
+
+1. `osoji safety check` — blocks the commit if staged files contain:
+   - Personal filesystem paths (e.g. `/Users/jsmith/`, `C:\Users\`)
+   - Secrets and API keys (via detect-secrets)
+2. `osoji check .` — marks stale shadow docs and stages the refreshed
+   `.osoji/shadow/` docs and staleness manifest; informational only (no LLM
+   calls, never blocks the commit)
+
+Only step 1 is a security control; step 2 is documentation hygiene that rides
+the same hook.
 
 ## Verifying package authenticity
 

--- a/docs/tutorials/protecting-repo-with-safety-checks.md
+++ b/docs/tutorials/protecting-repo-with-safety-checks.md
@@ -333,7 +333,7 @@ osoji safety check src/*.py docs/*.md
 
 Osoji automatically skips certain files and directories:
 
-**Checked extensions**: `.py`, `.pyi`, `.js`, `.ts`, `.jsx`, `.tsx`, `.json`, `.yaml`,
+**Checked extensions**: `.py`, `.pyi`, `.js`, `.ts`, `.mjs`, `.jsx`, `.tsx`, `.json`, `.yaml`,
 `.yml`, `.toml`, `.ini`, `.cfg`, `.md`, `.txt`, `.rst`, `.sh`, `.bash`,
 `.zsh`, `.env`, `.sql`, `.xml`, `.html`, `.htm`
 
@@ -779,15 +779,16 @@ class CheckResult:
 
     @property
     def passed(self) -> bool:
-        return not self.path_findings and not self.secret_findings
+        return not self.path_findings and not self.secret_findings and not self.errors
 
     @property
     def finding_count(self) -> int:
         return len(self.path_findings) + len(self.secret_findings)
 ```
 
-The `passed` property returns `True` only when both `path_findings` and
-`secret_findings` are empty. Any finding of either type causes failure.
+The `passed` property returns `True` only when `path_findings`,
+`secret_findings`, and `errors` are all empty. Any finding of either type —
+or any error encountered while checking — causes failure.
 
 Multiple `CheckResult` instances can be merged with the `merge()` method,
 which concatenates findings and sums file counts.

--- a/src/osoji/skills/osoji-sweep.md
+++ b/src/osoji/skills/osoji-sweep.md
@@ -129,7 +129,8 @@ about to happen:
 > Uploading audit results to your configured osoji-teams endpoint at ENDPOINT_URL…
 
 To resolve the endpoint for the message, read it from (in priority order):
-`OSOJI_ENDPOINT` env var, `.osoji.toml` `[push].endpoint`, or
+`OSOJI_ENDPOINT` env var, `.osoji.local.toml` `[push].endpoint`,
+`.osoji.toml` `[push].endpoint`, or
 `~/.config/osoji/config.toml` `[push].endpoint`.
 
 Then run:


### PR DESCRIPTION
## Summary

The four genuine doc-accuracy drifts adjudicated in `tests/fixtures/bootstrap/ab-v15d-report.md` (osojicode/work#53), each re-verified against current source before editing:

1. **safety-checks tutorial** — the `passed` listing and prose now include the `errors` condition (`models.py:38-40`); `.mjs` added to the checked-extensions list (present in `CHECKABLE_EXTENSIONS`). Note: the ticket also flagged a missing `errors` field in the dataclass listing — that field was already present; only the `passed` body and prose were stale.
2. **CLAUDE.md** — `src/osoji/llm/` line now says direct SDKs. The CHANGELOG's 'all via LiteLLM' line sits under the released `[0.2.0]` section and was **true at release time** (LiteLLM was removed 2026-04-26 in #66, after the 2026-03-23 release), so instead of rewriting history I added an `[Unreleased] – Changed` entry recording the migration.
3. **osoji-sweep skill + `.claude` mirror** — endpoint priority order now includes `.osoji.local.toml` between the env var and `.osoji.toml` (matches `push.py` precedence). `tests/test_skills_parity.py` green.
4. **SUPPLY-CHAIN-SECURITY.md** — pre-commit section now describes the real two-step chain from `hooks.py`: blocking `osoji safety check`, then informational `osoji check .` (stages refreshed shadow docs, never blocks).

Docs-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)