### PR TITLE
fix Phase 3 debris cross-wiring guard: chunked decide + path:line fallback echo

### DIFF
--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -48,7 +48,7 @@ from .audit_manifest import (
     merge_verdicts,
     write_manifest,
 )
-from .triage import TRIAGE_SYSTEM_PROMPT, Triage
+from .triage import TRIAGE_SYSTEM_PROMPT
 try:
     from tabulate import tabulate as _tabulate
 except ModuleNotFoundError:
@@ -746,11 +746,14 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
     """Phase 3: Triage debris findings against cross-file evidence.
 
     Builds self-sufficient claims for the eligible debris subset (the same subset
-    the legacy verify step gated on) and decides them in one claim-mode Triage
-    call. A ``dismissed`` verdict suppresses the finding — preserving the prior
-    behavior where a confirmed-false-positive was dropped. Best-effort: on any
-    failure all findings are kept.
+    the legacy verify step gated on) and decides them through the shared chunked
+    decide loop (work#57: the V1-5e A/B saw a whole-corpus single call go
+    off-by-one from ~index 5; bounded chunks match every Phase 4 analyzer). A
+    ``dismissed`` verdict suppresses the finding — preserving the prior behavior
+    where a confirmed-false-positive was dropped. Best-effort: on any failure
+    all findings are kept.
     """
+    from .junk_triage import decide_junk_claims
     _emit(config, "Osoji: Checking code debris findings...")
     phase_start = time_module.monotonic()
     suppressed_indices: set[int] = set()
@@ -760,20 +763,19 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
         try:
             claims, original_indices, would_escalate = build_debris_claims(config, raw_debris)
             if claims:
-                session = getattr(config, "verdict_session", None)
-                triage = Triage(config, rate_limiter)
-                result = await triage.decide_batch(
-                    claims,
-                    mode="claim",
-                    system_prompt=TRIAGE_SYSTEM_PROMPT,
-                    verdict_cache=session.cache if session is not None else None,
-                )
-                if session is not None:
-                    session.harvest(result.findings)
-                for finding, orig_idx in zip(result.findings, original_indices):
+                # decide_junk_claims handles the verdict-session cache and
+                # harvest itself (V1-9), so no manual session plumbing here.
+                provider, _ = create_runtime(config, rate_limiter=rate_limiter)
+                try:
+                    decided, in_tok, out_tok = await decide_junk_claims(
+                        claims, config, provider, system_prompt=TRIAGE_SYSTEM_PROMPT,
+                    )
+                finally:
+                    await provider.close()
+                for finding, orig_idx in zip(decided, original_indices):
                     if finding.verdict == "dismissed":
                         suppressed_indices.add(orig_idx)
-                phase_tokens = (result.input_tokens, result.output_tokens)
+                phase_tokens = (in_tok, out_tok)
             if suppressed_indices and verbose:
                 _emit(config, f"  Dismissed {len(suppressed_indices)} false positive debris finding(s)")
             # Dormant escalation tally (decision 0014): eligible findings whose

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -233,6 +233,21 @@ class TriageBatchResult:
 _MAX_EXPLORATION_TURNS = 8
 
 
+def _claim_echo(finding: Finding) -> str:
+    """Identity token a batch verdict must echo back (cross-wiring guard).
+
+    The claim's symbol when it has one; otherwise a ``path:line`` fallback so
+    symbol-less claims (debris) still carry an identity the completeness
+    validator can check (work#57 — the V1-5e A/B saw off-by-one verdicts
+    survive validation because ``symbol=None`` left nothing to compare).
+    """
+    if finding.symbol:
+        return finding.symbol
+    if finding.line_start:
+        return f"{finding.path}:{finding.line_start}"
+    return finding.path
+
+
 class Triage:
     """The unified Triage stage.
 
@@ -363,10 +378,11 @@ class Triage:
             ]
             # Symbol echo guard: sibling claims (two params of one function)
             # are easy to cross-wire by index alone — a mismatched echo means
-            # the verdict was written about a different claim.
+            # the verdict was written about a different claim. Symbol-less
+            # claims (debris) are guarded by their path:line fallback echo.
             for i, claim in enumerate(claims):
                 echoed = (by_index.get(i) or {}).get("symbol")
-                expected = claim.finding.symbol
+                expected = _claim_echo(claim.finding)
                 if echoed and expected and echoed != expected:
                     errors.append(
                         f"Verdict for batch_index {i} echoes symbol '{echoed}' but "
@@ -423,8 +439,7 @@ class Triage:
         if finding.line_start:
             loc += f":L{finding.line_start}-{finding.line_end}"
         lines = [f"### Claim {index}: {finding.detector} [{finding.gap_type}] — {loc}"]
-        if finding.symbol:
-            lines.append(f"Symbol: `{finding.symbol}`")
+        lines.append(f"Symbol: `{_claim_echo(finding)}`")
         lines.append(f"Claim ({finding.contract_source}): {finding.contract_claim}")
         lines.append(f"Observed: {finding.observed_behavior}")
         if finding.evidence:

--- a/tests/test_audit_debris_cutover.py
+++ b/tests/test_audit_debris_cutover.py
@@ -69,7 +69,8 @@ def _debris(category, description, **over):
 def _run(config, raw, provider):
     with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
          patch("osoji.symbols.load_all_symbols", return_value={}), \
-         patch("osoji.triage.create_runtime", return_value=(provider, MagicMock())):
+         patch("osoji.triage.create_runtime", return_value=(provider, MagicMock())), \
+         patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
         return asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
 
 
@@ -107,6 +108,31 @@ def test_ineligible_only_makes_no_llm_call(temp_dir):
     assert suppressed == set()
     assert phase_tokens == (0, 0)
     assert provider.calls == 0
+
+
+def test_debris_corpus_is_decided_in_bounded_chunks(temp_dir):
+    # work#57: the V1-5e A/B saw a whole-corpus decide_batch (62 claims) go
+    # off-by-one from ~index 5. Phase 3 must chunk like every Phase 4 analyzer
+    # (decide_junk_claims, BATCH_SIZE=12) instead of one monolithic call.
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    raw = [
+        _debris("dead_code", f"`helper_{i}` is defined but never used", line_start=i + 1, line_end=i + 1)
+        for i in range(13)
+    ]
+    # The same canned result serves every chunk: batch_index 0 dismissed, the
+    # rest confirmed. Chunk 1 (claims 0-11) suppresses raw index 0; chunk 2
+    # (claim 12 alone) sees its only claim at batch_index 0 → also dismissed.
+    provider = FakeProvider(_verdicts_result(
+        [{"batch_index": 0, "verdict": "dismissed", "confidence": 0.9, "reasoning": "alive"}]
+        + [{"batch_index": i, "verdict": "confirmed", "confidence": 0.8, "reasoning": "dead"}
+           for i in range(1, 12)]
+    ))
+
+    suppressed, phase_tokens = _run(config, raw, provider)
+
+    assert provider.calls == 2  # 13 claims → chunks of 12 + 1
+    assert suppressed == {0, 12}
+    assert phase_tokens == (240, 120)
 
 
 def test_debris_triage_uses_unified_rubric(temp_dir):

--- a/tests/test_audit_incremental.py
+++ b/tests/test_audit_incremental.py
@@ -234,7 +234,7 @@ def test_merge_keeps_foreign_producers_and_drops_disappeared(temp_dir):
     assert any(e["detector"].startswith("obligations:") for e in rewritten.values())
 
 
-# --- debris seam (Phase 3 direct decide_batch call) -----------------------------
+# --- debris seam (Phase 3, chunked via decide_junk_claims since work#57) --------
 
 
 class _FakeFacts:
@@ -279,7 +279,7 @@ def test_debris_seam_serves_cache_without_llm(temp_dir):
 
     with patch("osoji.facts.FactsDB", return_value=_FakeFacts()), \
          patch("osoji.symbols.load_all_symbols", return_value={}), \
-         patch("osoji.triage.create_runtime", return_value=(provider, MagicMock())):
+         patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
         suppressed, _tokens = asyncio.run(
             _run_phase3_async(config, raw_debris, MagicMock(), False)
         )

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -166,6 +166,57 @@ async def test_claim_mode_uses_supplied_system_prompt(config):
     assert provider.calls[0]["system"] == "CUSTOM-RUBRIC"
 
 
+# --- cross-wiring guard for symbol-less claims (work#57) --------------------
+
+
+@pytest.mark.asyncio
+async def test_symbolless_claim_renders_location_echo(config):
+    # Debris claims routinely carry symbol=None; without a rendered identity
+    # there is nothing for the verdict to echo and misalignment survives.
+    finding = make_finding(symbol=None, path="src/x.py", line_start=10)
+    provider = FakeProvider([
+        verdicts_result([{"batch_index": 0, "verdict": "confirmed", "confidence": 0.9, "reasoning": "dead"}])
+    ])
+    triage = Triage(config, provider=provider)
+
+    await triage.decide_batch([Claim(finding)], mode="claim")
+
+    user_msg = provider.calls[0]["messages"][0].content
+    assert "Symbol: `src/x.py:10`" in user_msg
+
+
+@pytest.mark.asyncio
+async def test_completeness_validator_catches_cross_wired_symbolless_claims(config):
+    # The V1-5e A/B observed off-by-one verdicts surviving validation because
+    # the symbol-echo guard has nothing to compare on symbol=None claims. The
+    # path:line fallback echo must make cross-wiring a validation error.
+    claims = [
+        Claim(make_finding(symbol=None, path="src/a.py", line_start=3, line_end=3)),
+        Claim(make_finding(symbol=None, path="src/b.py", line_start=7, line_end=7)),
+    ]
+    provider = FakeProvider([
+        verdicts_result([
+            {"batch_index": 0, "verdict": "confirmed", "confidence": 0.9, "reasoning": "x"},
+            {"batch_index": 1, "verdict": "dismissed", "confidence": 0.8, "reasoning": "y"},
+        ])
+    ])
+    triage = Triage(config, provider=provider)
+    await triage.decide_batch(claims, mode="claim")
+    validator = provider.calls[0]["options"].tool_input_validators[0]
+
+    cross_wired = validator("submit_triage_verdicts", {"verdicts": [
+        {"batch_index": 0, "symbol": "src/b.py:7", "verdict": "confirmed", "confidence": 0.9, "reasoning": "x"},
+        {"batch_index": 1, "symbol": "src/a.py:3", "verdict": "dismissed", "confidence": 0.8, "reasoning": "y"},
+    ]})
+    assert len(cross_wired) == 2
+
+    aligned = validator("submit_triage_verdicts", {"verdicts": [
+        {"batch_index": 0, "symbol": "src/a.py:3", "verdict": "confirmed", "confidence": 0.9, "reasoning": "x"},
+        {"batch_index": 1, "symbol": "src/b.py:7", "verdict": "dismissed", "confidence": 0.8, "reasoning": "y"},
+    ]})
+    assert aligned == []
+
+
 # --- evidence rendering (V1-4 kinds) ----------------------------------------
 
 


### PR DESCRIPTION
Closes the two gaps from osojicode/work#57 (found in the V1-5e rubric A/B, where a whole-corpus `decide_batch` went off-by-one from ~index 5 and survived validation).

## What changed

1. **Phase 3 debris now decides in bounded chunks.** `_run_phase3_async` routes through the shared `decide_junk_claims` loop (BATCH_SIZE=12, same-file adjacency, bisect-on-failure) instead of one monolithic `decide_batch` over the whole corpus — the same seam every Phase 4 analyzer uses. The V1-9 verdict-session cache/harvest is handled inside the shared loop, so the manual session plumbing in Phase 3 is gone.

2. **Symbol-less claims get an identity echo.** `_render_claim_block` now renders a `Symbol:` line for every claim — `path:line_start` when the finding has no symbol (debris claims routinely don't) — and `check_completeness` validates the echo against the same fallback. Cross-wired verdicts on symbol-less claims are now a validation error (retry), regardless of batch size.

## Signal conservation

Chunking changes no verdict semantics. The echo fallback only rejects structurally-invalid responses (misaligned batch_index → retry); no finding is ever suppressed by either change.

## Tests

- `test_debris_corpus_is_decided_in_bounded_chunks` — 13 eligible debris findings → 2 provider calls (12+1), suppression indices correctly aligned across chunks.
- `test_symbolless_claim_renders_location_echo` — the rendered prompt carries ``Symbol: `src/x.py:10` `` for a symbol=None claim.
- `test_completeness_validator_catches_cross_wired_symbolless_claims` — cross-wired echoes produce 2 validation errors; aligned echoes produce none.

All written red-first; full suite 1169 passed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
