### PR TITLE
fix backtick needle extraction: accept name() call forms, drop degenerate segments

### DIFF
--- a/src/osoji/evidence_builders.py
+++ b/src/osoji/evidence_builders.py
@@ -161,8 +161,9 @@ def _extract_all_symbols_from_debris(description: str) -> list[str]:
     names: list[str] = []
     seen: set[str] = set()
     # 1. Backtick-quoted names (dotted allowed — FactsDB resolves
-    #    `Class.method` including bare-method dispatch matching)
-    for m in re.finditer(r"`([\w.]+)`", description):
+    #    `Class.method` including bare-method dispatch matching; a trailing
+    #    `()` call form contributes the callable's name — work#58)
+    for m in re.finditer(r"`([\w.]+)(?:\(\))?`", description):
         name = m.group(1).strip(".")
         if name and name.lower() not in _SYMBOL_FILLER and name not in seen:
             names.append(name)
@@ -308,21 +309,29 @@ def _match_in_quotes(line: str, pos: int) -> bool:
 
 
 def _backticked_names(text: str) -> list[str]:
-    """Backticked identifiers, including dotted ones.
+    """Backticked identifiers, including dotted ones and `name()` call forms.
 
     A dotted name contributes both the qualified form and its bare last
     segment — `Class.method` reachability lives at `obj.method(` call sites
     and string-dispatch keys that name only the method (the dead_symbol-001
     lesson: the plain-word pattern silently skipped dotted names, so the
-    method was never swept and its dispatch string stayed invisible).
+    method was never swept and its dispatch string stayed invisible). Call
+    forms contribute the callable's name (the work#58 lesson: `name()` never
+    matched, so the sweep ran on junk needles and produced false
+    evidence-of-absence under an honest-looking scope). Derived bare segments
+    of <=2 chars are skipped — `__init__.py` must not derive a `py` needle
+    whose extreme hit count fills the cap with noise; the explicit qualified
+    token always stays.
     """
 
     seen: list[str] = []
-    for match in re.finditer(r"`([\w.]+)`", text):
+    for match in re.finditer(r"`([\w.]+)(?:\(\))?`", text):
         name = match.group(1).strip(".")
         candidates = [name]
         if "." in name:
-            candidates.append(name.rsplit(".", 1)[-1])
+            segment = name.rsplit(".", 1)[-1]
+            if len(segment) > 2:
+                candidates.append(segment)
         for candidate in candidates:
             if candidate and candidate.lower() not in _SYMBOL_FILLER and candidate not in seen:
                 seen.append(candidate)

--- a/tests/test_claim_builder.py
+++ b/tests/test_claim_builder.py
@@ -70,6 +70,15 @@ def test_all_caps_is_not_pascalcase():
     assert "ABCDEF" not in _extract_all_symbols_from_debris("token ABCDEF here Aa")
 
 
+def test_backticked_call_form_extracts_function_name():
+    # work#58: `name()` never matched the backtick pattern, so the FactsDB
+    # lookup (and the text sweep) ran without the one symbol the claim is about.
+    names = _extract_all_symbols_from_debris(
+        "`_discover_entry_point_plugins()` is defined but never called"
+    )
+    assert "_discover_entry_point_plugins" in names
+
+
 @pytest.fixture
 def config(temp_dir):
     return Config(root_path=temp_dir, respect_gitignore=False)

--- a/tests/test_evidence_builders.py
+++ b/tests/test_evidence_builders.py
@@ -539,6 +539,61 @@ def test_backticked_dotted_names_yield_qualified_and_bare_needles(config, temp_d
     assert hits and hits[0].get("in_string_literal") is True
 
 
+def test_backticked_call_forms_yield_the_function_needle():
+    # work#58: `name()` never matched the backtick pattern (the trailing
+    # parentheses are outside the character class), so the sweep ran on junk
+    # needles and produced false evidence-of-absence with an honest-looking
+    # scope. The rubric then confirmed a ground-truth false positive.
+    from osoji.evidence_builders import _backticked_names
+
+    names = _backticked_names(
+        "`_discover_entry_point_plugins()` is defined but never called"
+    )
+    assert "_discover_entry_point_plugins" in names
+
+    dotted = _backticked_names("`Widget.render()` appears unused")
+    assert "Widget.render" in dotted
+    assert "render" in dotted
+
+
+def test_dotted_name_does_not_derive_degenerate_bare_segment():
+    # `__init__.py` is a dotted token; its derived bare segment `py` was a
+    # 71K-hit junk needle in the work#58 incident. The qualified token stays;
+    # the degenerate derivation goes.
+    from osoji.evidence_builders import _backticked_names
+
+    names = _backticked_names("referenced only from `__init__.py`")
+    assert "__init__.py" in names
+    assert "py" not in names
+
+
+def test_call_form_function_referenced_only_in_package_init_is_found(config, temp_dir):
+    # The work#58 ground truth, as a fixture: a debris description carrying a
+    # backticked call-form private function whose only reference is a call in
+    # the package `__init__.py`. The function must be swept and the call found.
+    write(temp_dir, "src/pkg/registry.py",
+          "def _discover_entry_point_plugins():\n    pass\n")
+    write(temp_dir, "src/pkg/__init__.py",
+          "from .registry import _discover_entry_point_plugins\n"
+          "PLUGINS = _discover_entry_point_plugins()\n")
+    finding = make_finding(
+        path="src/pkg/registry.py",
+        symbol=None,
+        line_start=1,
+        line_end=2,
+        contract_claim="`_discover_entry_point_plugins()` is defined but never called",
+        observed_behavior="only `__init__.py` mentions the module",
+    )
+    ctx = BuildContext(config, facts_db=FakeFacts(), symbols_by_file={})
+    evidence = BUILDERS["cross_file_reference"].build(finding, ctx)
+    scope = evidence[0].payload["scan_scope"]
+    assert "_discover_entry_point_plugins" in scope["needles"]
+    assert "py" not in scope["needles"]
+    hits = [r for r in evidence[0].payload["references"]
+            if r["file"] == "src/pkg/__init__.py"]
+    assert hits  # the call site was swept and found
+
+
 def test_sweep_orders_by_proximity_to_flagged_file(config, temp_dir):
     # V1-5a dead_symbol-002 lesson: a committed corpus's own JSON artifacts
     # (source-ranked extensions) crowded out the flagged file's sibling-package


### PR DESCRIPTION
Closes the evidence-fidelity gaps from osojicode/work#58 (found via a ground-truth check in the V1-5e A/B adjudication: the sweep for a dead-code claim ran on junk needles, produced false evidence-of-absence with an honest-looking scope, and the rubric — correctly, per its evidence — confirmed a false positive at 0.85).

## What changed

1. **Call forms extract.** The backtick pattern in `_backticked_names` and `_extract_all_symbols_from_debris` couldn't match `` `name()` `` (trailing parentheses were outside the character class), so `` `_discover_entry_point_plugins()` `` contributed nothing — the claim's one subject symbol was never swept nor looked up in FactsDB. Both patterns now accept an optional trailing `()`. Dotted call forms (`` `Widget.render()` ``) contribute both the qualified name and the bare method segment, as before.

2. **Degenerate derived segments are skipped.** A dotted token's derived bare last segment is dropped when ≤2 chars: `` `__init__.py` `` no longer derives a `py` needle (71,359 corpus hits in the incident — pure cap-filling noise). The explicit qualified token always survives; only our own derivation is filtered.

Not implemented here: hit-count-based needle suppression via `needle_totals` (the ticket's second "consider"). Its signal-conservation impact is less clear-cut — noted on work#58 as a possible follow-up.

## Signal conservation

Both changes only improve evidence fidelity. No finding is suppressed mechanically — garbage needles in, confident garbage out was the failure; the fix is better needles, not fewer findings.

## Tests

- `test_backticked_call_form_extracts_function_name` / `test_backticked_call_forms_yield_the_function_needle` — call forms yield the callable's name (plain and dotted).
- `test_dotted_name_does_not_derive_degenerate_bare_segment` — `__init__.py` stays, `py` goes.
- `test_call_form_function_referenced_only_in_package_init_is_found` — the ticket's regression fixture: a backticked call-form private function whose only reference is a call in the package `__init__.py`; the call site must be swept and found. Red-first, it reproduced the incident needles `['__init__.py', 'py']` exactly.

Full suite: 1170 passed, 13 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
