### PR TITLE
true up observatory schema: drifted Scorecard fields + dataclass parity gate

### DIFF
--- a/src/osoji/osoji-observatory.schema.json
+++ b/src/osoji/osoji-observatory.schema.json
@@ -644,6 +644,18 @@
         "obligation_implicit_contracts": {
           "type": ["integer", "null"]
         },
+        "contract_claims_triaged": {
+          "description": "Contract claims that received a Triage verdict this run (V1-5c); null if --obligations not run.",
+          "type": ["integer", "null"]
+        },
+        "contract_claims_other": {
+          "description": "Triaged contract claims routed to the string-contract taxonomy's 'other' safety valve — the CE-gap numerator (V1-5c); null if --obligations not run.",
+          "type": ["integer", "null"]
+        },
+        "verdict_cache_hit_rate": {
+          "description": "Fraction of Triage claims served from the incremental verdict cache this run (V1-9); null when no claims reached a Triage seam.",
+          "type": ["number", "null"]
+        },
         "concept_total": {
           "type": ["integer", "null"]
         },

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -415,6 +415,23 @@ def test_schema_file_is_valid_json():
     jsonschema.Draft202012Validator.check_schema(schema)
 
 
+@pytest.mark.parametrize("def_name", ["Scorecard", "CoverageEntry", "JunkCodeEntry"])
+def test_bundle_dataclass_defs_match_schema(def_name):
+    # The bundle embeds these dataclasses via asdict, so each schema def must
+    # carry exactly the dataclass's fields. The schema has no closed objects,
+    # so a missing property does not fail validation — it silently drops the
+    # field out of the contract osoji-teams codes against. This gate is what
+    # makes that drift loud (three Scorecard fields drifted V1-4..V1-9).
+    import dataclasses
+
+    from osoji import scorecard as scorecard_mod
+
+    dc = getattr(scorecard_mod, def_name)
+    schema_props = set(_load_schema()["$defs"][def_name]["properties"])
+    dataclass_fields = {f.name for f in dataclasses.fields(dc)}
+    assert schema_props == dataclass_fields
+
+
 def test_minimal_bundle_validates_against_schema(temp_dir):
     _write_source(temp_dir, "main.py", "x = 1\n")
 


### PR DESCRIPTION
Contract-drift true-up for the observatory bundle, found while assessing whether to push bundles to osoji-teams during the rebuild.

## What drifted

Three `Scorecard` fields the bundle carries but `osoji-observatory.schema.json` never learned:

- `contract_claims_triaged` / `contract_claims_other` — V1-5c (obligations migration; the CE-gap metric)
- `verdict_cache_hit_rate` — V1-9 (incremental audit)

Validation stayed green throughout because the schema has no closed objects (`additionalProperties: false` appears nowhere), so unknown fields pass silently — the drift never failed a test, it just quietly left the osoji-teams contract behind.

## What changed

1. The three properties added to the schema's `Scorecard` def, with descriptions and the same `null`-when-not-run semantics as their siblings.
2. A parity gate: `test_bundle_dataclass_defs_match_schema` asserts each dataclass-backed def (`Scorecard`, `CoverageEntry`, `JunkCodeEntry`) carries exactly its dataclass's fields (the bundle embeds them via `asdict`). The next drifted field fails CI instead of drifting silently. `CoverageEntry`/`JunkCodeEntry` were verified already in parity — the gate just locks them.

Checked and clean: bundle top-level properties, audit-finding projection, doc-analysis projection, and file-node shape are all fixed projections in `observatory.py` — no other drift.

## osoji-teams coordination

Purely additive; the ingest API needs no change to keep accepting existing bundles. The dashboard MAY start reading the three new fields (`verdict_cache_hit_rate` is the headline one for incremental-audit visibility).

Full suite: 1169 passed, 13 skipped (observatory module: 19 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
