### PR TITLE
bound token-count cache with LRU eviction instead of silent stop

### DIFF
--- a/src/osoji/llm/tokens.py
+++ b/src/osoji/llm/tokens.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -11,6 +12,10 @@ if TYPE_CHECKING:
 from ..config import ANTHROPIC_MODEL_MEDIUM, DEFAULT_PROVIDER
 from .registry import normalize_provider_name, strip_provider_prefix
 from .types import Message, MessageRole, ToolDefinition
+
+# Bounds memory growth of the per-text count cache in long-lived counters;
+# least-recently-used entries are evicted once the bound is reached.
+_MAX_CACHE_ENTRIES = 10_000
 
 
 class TokenCounter:
@@ -25,7 +30,7 @@ class TokenCounter:
         self._provider = normalize_provider_name(provider)
         self._default_model = default_model
         self._client: AsyncAnthropic | None = None
-        self._cache: dict[str, int] = {}
+        self._cache: OrderedDict[str, int] = OrderedDict()
 
     @property
     def label(self) -> str:
@@ -91,16 +96,23 @@ class TokenCounter:
         return int(response.input_tokens)
 
     async def count_text_async(self, text: str) -> int:
+        """Count tokens for a single text, memoized in a bounded LRU cache.
+
+        The cache holds at most ``_MAX_CACHE_ENTRIES`` entries; the least
+        recently used entry is evicted when the bound is exceeded.
+        """
         resolved_model = self._resolved_model(None)
         cache_key = f"{self.cache_key_prefix}:{resolved_model}:{hash(text)}"
         if cache_key in self._cache:
+            self._cache.move_to_end(cache_key)
             return self._cache[cache_key]
 
         messages = [Message(role=MessageRole.USER, content=text)]
         count = await self.count_tokens_async(messages, model=resolved_model)
 
-        if len(self._cache) < 10_000:
-            self._cache[cache_key] = count
+        self._cache[cache_key] = count
+        if len(self._cache) > _MAX_CACHE_ENTRIES:
+            self._cache.popitem(last=False)
 
         return count
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,57 @@
+"""Tests for the bounded LRU cache in TokenCounter.count_text_async."""
+
+import pytest
+
+from osoji.llm.tokens import TokenCounter
+
+
+def _counter() -> TokenCounter:
+    # Non-Anthropic provider routes to the offline estimator: no network.
+    return TokenCounter(provider="openai", default_model="gpt-4o")
+
+
+def _key_for(counter: TokenCounter, text: str) -> str:
+    return f"{counter.cache_key_prefix}:{counter._resolved_model(None)}:{hash(text)}"
+
+
+@pytest.mark.asyncio
+async def test_count_text_caches_repeat_counts():
+    counter = _counter()
+    text = "hello world " * 10
+
+    first = await counter.count_text_async(text)
+    second = await counter.count_text_async(text)
+
+    assert first == second
+    assert len(counter._cache) == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_evicts_oldest_entry_past_the_bound(monkeypatch):
+    monkeypatch.setattr("osoji.llm.tokens._MAX_CACHE_ENTRIES", 3)
+    counter = _counter()
+
+    texts = [f"text number {i} " * (i + 1) for i in range(4)]
+    counts = [await counter.count_text_async(t) for t in texts]
+
+    assert len(counter._cache) == 3
+    assert _key_for(counter, texts[0]) not in counter._cache
+    assert all(_key_for(counter, t) in counter._cache for t in texts[1:])
+    # Evicted entries are recomputed correctly, not lost.
+    assert await counter.count_text_async(texts[0]) == counts[0]
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_refreshes_recency(monkeypatch):
+    monkeypatch.setattr("osoji.llm.tokens._MAX_CACHE_ENTRIES", 2)
+    counter = _counter()
+
+    a, b, c = "alpha " * 3, "bravo " * 5, "charlie " * 7
+    await counter.count_text_async(a)
+    await counter.count_text_async(b)
+    await counter.count_text_async(a)  # hit: a becomes most recent
+    await counter.count_text_async(c)  # evicts b, not a
+
+    assert _key_for(counter, a) in counter._cache
+    assert _key_for(counter, b) not in counter._cache
+    assert _key_for(counter, c) in counter._cache


### PR DESCRIPTION
## What

`TokenCounter.count_text_async` (src/osoji/llm/tokens.py) capped its per-text cache by silently refusing inserts past 10,000 entries — a bare literal with no named constant, no docstring mention, and no eviction. This PR:

- names the bound (`_MAX_CACHE_ENTRIES = 10_000`) with a comment declaring its intent (bound memory growth in long-lived counters),
- converts the cache to an `OrderedDict` LRU: hits refresh recency, inserts past the bound evict the least-recently-used entry,
- documents the behavior in the docstring,
- adds `tests/test_tokens.py`: repeat-count caching, eviction past the bound (evicted entries recompute correctly), and hit-refreshes-recency.

## Why

Remediation for the `llm/tokens.py:102` finding ratified **confirmed@info** in the v159 A/B adjudication (osojicode/work#59, ruling addendum in `tests/fixtures/bootstrap/ab-v159-report.md`). The old bound bound memory correctly but silently stopped caching at ~5K files under `osoji stats` (two texts per file) — inside the target repo population. LRU keeps the memory bound and removes the silent behavior cliff.

## Notes

- The shadow doc for tokens.py will be marked stale by the check hook; regeneration is a deliberate LLM-billed step left out of this PR.
- If the `audit` check fails on click PYSEC-2026-2132, that is the pre-existing dependency advisory (fixed in a separate security PR); re-run checks after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)