### PR TITLE
Security: raise click floor to 8.3.3 (PYSEC-2026-2132)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "anthropic>=0.39.0",
-    "click>=8.1.0",
+    "click>=8.3.3",  # floor excludes PYSEC-2026-2132 (command injection in click.edit)
     "google-genai>=1.10.0",
     "openai>=1.75.0",
     "python-dotenv>=1.0.0",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -258,9 +258,9 @@ claude-agent-sdk==0.2.110 \
     --hash=sha256:62b23869d46cef6f6ff1d00ceaa5e846e2f1d297478421c835efb8fe99369d4f \
     --hash=sha256:fed0e0f4804d9f9cff80ab7d1b44142ebd1046cdd29ca74caef4c92c35fff8d8
     # via osojicode (pyproject.toml)
-click==8.1.8 \
-    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
-    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
+click==8.4.2 \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via
     #   osojicode (pyproject.toml)
     #   uvicorn

--- a/requirements.lock
+++ b/requirements.lock
@@ -240,9 +240,9 @@ charset-normalizer==3.4.6 \
     --hash=sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104 \
     --hash=sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659
     # via requests
-click==8.1.8 \
-    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
-    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
+click==8.4.2 \
+    --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
+    --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via osojicode (pyproject.toml)
 colorama==0.4.6 ; sys_platform == 'win32' \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \


### PR DESCRIPTION
## Incident

The `audit` CI job (pip-audit over `requirements.lock`) began failing on 2026-07-15: **click 8.1.8** falls in the advisory range for **PYSEC-2026-2132 / CVE-2026-7246 / GHSA-47fr-3ffg-hgmw** — command injection in `click.edit()`, fixed in 8.3.3 (advisory modified 2026-07-13, which is when the gate started tripping). This blocks every open PR, including #124.

## Exposure assessment

- **Not exploitable through osoji.** `click.edit()` is never called anywhere in `src/` (verified by search). CVSS 3.1 vector is `AV:L/AC:H/PR:H/UI:R` — local, high complexity, high privileges, user interaction required.
- click is a **direct** dependency (`click>=8.1.0`), pinned at 8.1.8 in `requirements.lock` and `requirements-dev.lock`; absent from `requirements-tools.lock`.
- No released osoji version is practically affected (the vulnerable function is unused), so no security advisory or patch release is warranted; this PR is the audit trail.

## Change

- `pyproject.toml`: floor raised to `click>=8.3.3` with a comment naming the advisory.
- Both project locks regenerated per the dependency workflow (`uv pip compile … --generate-hashes --universal`); **only click moved** (→ 8.4.2, the latest satisfying release): 6 lines per lock (version + hashes).

## Verification

- `pip-audit -r requirements.lock` → "No known vulnerabilities found"
- `pip install -e "."` → click 8.4.2 installs cleanly
- `pytest -m "not prompt_regression and not live_smoke"` → 1169 passed, 10 skipped
- (`test_dead_params_001_backward_compat` flaked once in a full-suite run and passed standalone — statistical trial test, unrelated to click)

## Follow-up

After merge, re-run checks on #124 and #130 (both currently fail only the `audit` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)