### PR TITLE
make best-effort audit degradation observable (degraded_phases)

### DIFF
--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -164,7 +164,7 @@ def _emit(config: Config, message: str = "", *, end: str = "\n") -> None:
 
 
 def _record_degradation(config: Config, phase: str, exc: Exception) -> None:
-    """Record a best-effort Triage/manifest seam failure (Track 2 PR-A).
+    """Record a best-effort Triage/manifest seam failure.
 
     Uses ``getattr`` so the seams stay safe when ``run_audit_async`` hasn't
     attached the list (e.g. unit tests calling a phase function directly) —
@@ -398,8 +398,8 @@ async def run_audit_async(
             verdict_cache = cache_from_verdicts(previous_manifest["verdicts"])
     session = VerdictSession(cache=verdict_cache)
     config.verdict_session = session
-    # Track 2 PR-A: every best-effort Triage/manifest seam appends here on
-    # failure instead of swallowing the exception silently.
+    # Every best-effort Triage/manifest seam appends here on failure instead
+    # of swallowing the exception silently.
     config.audit_degradations = []
 
     # Shared rate limiter across all phases so token budgets are tracked globally
@@ -610,8 +610,10 @@ async def run_audit_async(
     scorecard.verdict_cache_hit_rate = session.hit_rate
     if use_cache and session.claims_seen:
         _emit(config, f"Verdict cache: {session.cache_hits}/{session.claims_seen} hit(s)")
-    # Track 2 PR-A: surface any best-effort degradation recorded so far
-    # (debris-triage, obligations-triage — both run before this phase).
+    # Surface any best-effort degradation recorded so far (debris-triage,
+    # obligations-triage — both run before this phase). manifest-write runs
+    # after the scorecard is first serialized below, so this gets refreshed
+    # and re-serialized once more near the end of the function.
     scorecard.degraded_phases = _degraded_phases(config)
     _serialize_json(config.scorecard_path, asdict(scorecard))
 
@@ -718,6 +720,14 @@ async def run_audit_async(
         # so the degradation must still be recorded and visible.
         _record_degradation(config, "manifest-write", exc)
         _emit(config, f"[warn] manifest-write failed; findings kept unverified: {exc}")
+
+    # manifest-write can add a degradation after the scorecard and audit
+    # result were first serialized above; refresh and re-serialize both so
+    # this run's persisted output agrees with the in-memory result returned
+    # below (mirrors the Phase 5.5 doc-prompts re-serialize).
+    scorecard.degraded_phases = _degraded_phases(config)
+    _serialize_json(config.scorecard_path, asdict(scorecard))
+    serialize_audit_result(config, result)
 
     return result
 

--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -163,6 +163,26 @@ def _emit(config: Config, message: str = "", *, end: str = "\n") -> None:
     print(message, end=end, flush=True)
 
 
+def _record_degradation(config: Config, phase: str, exc: Exception) -> None:
+    """Record a best-effort Triage/manifest seam failure (Track 2 PR-A).
+
+    Uses ``getattr`` so the seams stay safe when ``run_audit_async`` hasn't
+    attached the list (e.g. unit tests calling a phase function directly) —
+    mirrors how junk_triage.py reads the V1-9 ``verdict_session`` attach.
+    """
+    degradations = getattr(config, "audit_degradations", None)
+    if degradations is not None:
+        degradations.append({"phase": phase, "error": str(exc)})
+
+
+def _degraded_phases(config: Config) -> list[str] | None:
+    """Sorted, deduplicated phase labels for degradations recorded so far."""
+    degradations = getattr(config, "audit_degradations", None)
+    if not degradations:
+        return None
+    return sorted({d["phase"] for d in degradations})
+
+
 def _make_progress_default(config: Config, rate_limiter=None):
     """Create an inline progress bar callback (carriage return, same line)."""
     def progress(completed: int, total: int, path: Path, status: str) -> None:
@@ -378,6 +398,9 @@ async def run_audit_async(
             verdict_cache = cache_from_verdicts(previous_manifest["verdicts"])
     session = VerdictSession(cache=verdict_cache)
     config.verdict_session = session
+    # Track 2 PR-A: every best-effort Triage/manifest seam appends here on
+    # failure instead of swallowing the exception silently.
+    config.audit_degradations = []
 
     # Shared rate limiter across all phases so token budgets are tracked globally
     rate_limiter = RateLimiter(get_config_with_overrides(config.provider or "anthropic"))
@@ -587,6 +610,9 @@ async def run_audit_async(
     scorecard.verdict_cache_hit_rate = session.hit_rate
     if use_cache and session.claims_seen:
         _emit(config, f"Verdict cache: {session.cache_hits}/{session.claims_seen} hit(s)")
+    # Track 2 PR-A: surface any best-effort degradation recorded so far
+    # (debris-triage, obligations-triage — both run before this phase).
+    scorecard.degraded_phases = _degraded_phases(config)
     _serialize_json(config.scorecard_path, asdict(scorecard))
 
     # ── Phase 5.5: doc prompts (optional, after scorecard) ──
@@ -686,8 +712,12 @@ async def run_audit_async(
             commit=get_head_commit(config.root_path),
             version=current_version(),
         )
-    except Exception:
-        pass  # the manifest is an optimization; never fail the audit over it
+    except Exception as exc:
+        # the manifest is an optimization; never fail the audit over it — but
+        # its silent death kills --incremental and future closure detection,
+        # so the degradation must still be recorded and visible.
+        _record_degradation(config, "manifest-write", exc)
+        _emit(config, f"[warn] manifest-write failed; findings kept unverified: {exc}")
 
     return result
 
@@ -787,8 +817,11 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
                 rate = would_escalate / eligible_total if eligible_total else 0.0
                 _emit(config, f"  {would_escalate} eligible finding(s) lacked gatherable evidence "
                               f"(would-escalate; kept unverified; escalation rate {rate:.1%})")
-        except Exception:
-            pass  # Triage is best-effort; on failure, keep all findings
+        except Exception as exc:
+            # Triage is best-effort; on failure, keep all findings — but the
+            # degradation must be recorded and visible.
+            _record_degradation(config, "debris-triage", exc)
+            _emit(config, f"[warn] debris-triage failed; findings kept unverified: {exc}")
     elapsed = time_module.monotonic() - phase_start
     tok_str = _format_tokens_short(phase_tokens[0], phase_tokens[1])
     if tok_str:
@@ -866,8 +899,10 @@ async def _run_phase3_5_async(config, obligations_enabled, rate_limiter, verbose
                 if df.verdict == "dismissed":
                     continue                                # dismissed = false positive -> suppress
                 kept.append(_overlay_verdict(cf, df))       # confirmed OR unverified(None) kept
-        except Exception:
+        except Exception as exc:
             kept = contract_findings                        # best-effort: keep all, unverified
+            _record_degradation(config, "obligations-triage", exc)
+            _emit(config, f"[warn] obligations-triage failed; findings kept unverified: {exc}")
     if verbose:
         n_violations = sum(1 for f in kept if f.finding_type == "violation")
         n_implicit = sum(1 for f in kept if f.finding_type == "implicit_contract")
@@ -1022,6 +1057,7 @@ def load_audit_result(config: Config) -> AuditResult:
             concept_partially_documented=sc.get("concept_partially_documented"),
             concept_undocumented=sc.get("concept_undocumented"),
             concept_coverage_by_type=sc.get("concept_coverage_by_type"),
+            degraded_phases=sc.get("degraded_phases"),
         )
 
     doc_prompts = None
@@ -1066,6 +1102,8 @@ def _format_scorecard_section(scorecard: Scorecard) -> list[str]:
         rate = other / scorecard.contract_claims_triaged
         summary_rows.append(["Contract taxonomy", f"{other}/{scorecard.contract_claims_triaged} 'other' "
                              f"({rate:.0%} CE-gap rate)"])
+    degradation_value = ", ".join(scorecard.degraded_phases) if scorecard.degraded_phases else "none"
+    summary_rows.append(["Triage degradation", degradation_value])
     lines.append(_table(["Metric", "Value"], summary_rows))
     lines.append("")
 

--- a/src/osoji/doc_analysis.py
+++ b/src/osoji/doc_analysis.py
@@ -592,9 +592,9 @@ async def analyze_docs_async(
     except Exception as e:
         if not config.quiet:
             print(f"  [warn] doc triage failed, keeping findings unverified: {e}", flush=True)
-        # Track 2 PR-A: record the degradation via the same mechanism audit.py's
-        # best-effort Triage seams use (getattr-safe: config.audit_degradations
-        # is only attached by run_audit_async).
+        # Record the degradation via the same mechanism audit.py's best-effort
+        # Triage seams use (getattr-safe: config.audit_degradations is only
+        # attached by run_audit_async).
         degradations = getattr(config, "audit_degradations", None)
         if degradations is not None:
             degradations.append({"phase": "doc-triage", "error": str(e)})

--- a/src/osoji/doc_analysis.py
+++ b/src/osoji/doc_analysis.py
@@ -592,6 +592,12 @@ async def analyze_docs_async(
     except Exception as e:
         if not config.quiet:
             print(f"  [warn] doc triage failed, keeping findings unverified: {e}", flush=True)
+        # Track 2 PR-A: record the degradation via the same mechanism audit.py's
+        # best-effort Triage seams use (getattr-safe: config.audit_degradations
+        # is only attached by run_audit_async).
+        degradations = getattr(config, "audit_degradations", None)
+        if degradations is not None:
+            degradations.append({"phase": "doc-triage", "error": str(e)})
 
     return results
 

--- a/src/osoji/observatory.py
+++ b/src/osoji/observatory.py
@@ -21,7 +21,7 @@ from .scorecard import merge_ranges
 from .walker import discover_directories, discover_files
 
 OBSERVATORY_SCHEMA_NAME = "osoji-observatory"
-OBSERVATORY_SCHEMA_VERSION = "1.2.0"
+OBSERVATORY_SCHEMA_VERSION = "1.3.0"
 _DEFAULT_OUTPUT_NAME = "observatory.json"
 _SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 

--- a/src/osoji/osoji-observatory.schema.json
+++ b/src/osoji/osoji-observatory.schema.json
@@ -682,6 +682,16 @@
             },
             { "type": "null" }
           ]
+        },
+        "degraded_phases": {
+          "description": "Best-effort Triage/manifest seams that failed this run, e.g. 'debris-triage' (Track 2 PR-A); null when nothing degraded.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            { "type": "null" }
+          ]
         }
       }
     }

--- a/src/osoji/osoji-observatory.schema.json
+++ b/src/osoji/osoji-observatory.schema.json
@@ -684,7 +684,7 @@
           ]
         },
         "degraded_phases": {
-          "description": "Best-effort Triage/manifest seams that failed this run, e.g. 'debris-triage' (Track 2 PR-A); null when nothing degraded.",
+          "description": "Phases where best-effort triage degraded during the audit run; null when none.",
           "anyOf": [
             {
               "type": "array",

--- a/src/osoji/scorecard.py
+++ b/src/osoji/scorecard.py
@@ -85,6 +85,11 @@ class Scorecard:
     concept_undocumented: int | None = None
     concept_coverage_by_type: dict[str, dict] | None = None
 
+    # Best-effort Triage/manifest degradation this run (Track 2 PR-A). None
+    # when nothing degraded; otherwise the sorted, deduplicated phase labels
+    # from config.audit_degradations (audit.py).
+    degraded_phases: list[str] | None = None
+
 
 def merge_ranges(ranges: list[tuple[int, int]]) -> list[tuple[int, int]]:
     """Merge overlapping integer ranges. Returns sorted, non-overlapping ranges."""

--- a/src/osoji/scorecard.py
+++ b/src/osoji/scorecard.py
@@ -85,9 +85,9 @@ class Scorecard:
     concept_undocumented: int | None = None
     concept_coverage_by_type: dict[str, dict] | None = None
 
-    # Best-effort Triage/manifest degradation this run (Track 2 PR-A). None
-    # when nothing degraded; otherwise the sorted, deduplicated phase labels
-    # from config.audit_degradations (audit.py).
+    # Best-effort Triage/manifest degradation this run. None when nothing
+    # degraded; otherwise the sorted, deduplicated phase labels from
+    # config.audit_degradations (audit.py).
     degraded_phases: list[str] | None = None
 
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -104,7 +104,7 @@ class TestConsoleTables:
         assert "Total" in text
 
 
-# --- Triage degradation summary row (Track 2 PR-A) ---
+# --- Triage degradation summary row ---
 
 class TestDegradationSummaryRow:
     def test_no_degradation_reports_none(self):
@@ -617,7 +617,7 @@ class TestAuditResultRoundTrip:
         assert loaded.passed is False
 
     def test_degraded_phases_round_trip(self, temp_dir):
-        """Scorecard.degraded_phases (Track 2 PR-A) survives serialize -> load."""
+        """Scorecard.degraded_phases survives serialize -> load."""
         from osoji.config import Config
 
         config = Config(root_path=temp_dir, respect_gitignore=False)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -104,6 +104,33 @@ class TestConsoleTables:
         assert "Total" in text
 
 
+# --- Triage degradation summary row (Track 2 PR-A) ---
+
+class TestDegradationSummaryRow:
+    def test_no_degradation_reports_none(self):
+        """degraded_phases is None (the Scorecard default) -> report says 'none'."""
+        sc = _minimal_scorecard()
+        assert sc.degraded_phases is None
+
+        lines = _format_scorecard_section(sc)
+        text = "\n".join(lines)
+        assert "Triage degradation" in text
+        assert "none" in text
+
+    def test_single_degraded_phase_named_in_report(self):
+        sc = _minimal_scorecard(degraded_phases=["debris-triage"])
+        lines = _format_scorecard_section(sc)
+        text = "\n".join(lines)
+        assert "Triage degradation" in text
+        assert "debris-triage" in text
+
+    def test_multiple_degraded_phases_joined_in_report(self):
+        sc = _minimal_scorecard(degraded_phases=["debris-triage", "manifest-write"])
+        lines = _format_scorecard_section(sc)
+        text = "\n".join(lines)
+        assert "debris-triage, manifest-write" in text
+
+
 # --- Uncovered files section ---
 
 class TestUncoveredFiles:
@@ -588,6 +615,33 @@ class TestAuditResultRoundTrip:
         assert loaded.has_errors is True
         assert loaded.has_warnings is True
         assert loaded.passed is False
+
+    def test_degraded_phases_round_trip(self, temp_dir):
+        """Scorecard.degraded_phases (Track 2 PR-A) survives serialize -> load."""
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        original = AuditResult(
+            issues=[],
+            scorecard=_minimal_scorecard(degraded_phases=["debris-triage", "manifest-write"]),
+        )
+
+        serialize_audit_result(config, original)
+        loaded = load_audit_result(config)
+
+        assert loaded.scorecard.degraded_phases == ["debris-triage", "manifest-write"]
+
+    def test_degraded_phases_none_round_trips_as_none(self, temp_dir):
+        """The no-degradation default (None) round-trips as None, not []."""
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        original = AuditResult(issues=[], scorecard=_minimal_scorecard())
+
+        serialize_audit_result(config, original)
+        loaded = load_audit_result(config)
+
+        assert loaded.scorecard.degraded_phases is None
 
 
 # --- Debris symbol extraction ---

--- a/tests/test_audit_debris_cutover.py
+++ b/tests/test_audit_debris_cutover.py
@@ -150,7 +150,7 @@ def test_debris_triage_uses_unified_rubric(temp_dir):
 
 
 def test_provider_failure_records_debris_triage_degradation(temp_dir):
-    """Track 2 PR-A: a Triage-seam failure keeps all findings AND is recorded.
+    """A Triage-seam failure keeps all findings AND is recorded.
 
     ``decide_junk_claims`` retries/bisects and swallows a per-chunk provider
     failure internally (findings come back undecided, verdict=None — see
@@ -170,3 +170,22 @@ def test_provider_failure_records_debris_triage_degradation(temp_dir):
     assert suppressed == set()  # best-effort: nothing suppressed, all kept
     assert phase_tokens == (0, 0)
     assert config.audit_degradations == [{"phase": "debris-triage", "error": "boom"}]
+
+
+def test_provider_failure_without_attached_degradations_list_does_not_crash(temp_dir):
+    """The getattr-absent safety path: config.audit_degradations is only
+    attached by run_audit_async, so a phase called directly (as every other
+    test in this module does) must not raise merely because the attribute
+    doesn't exist — it should keep findings exactly as before, silently."""
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    assert not hasattr(config, "audit_degradations")
+    raw = [_debris("dead_code", "`old_helper` is defined but never used")]
+
+    with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
+        suppressed, phase_tokens = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
+
+    assert suppressed == set()  # best-effort: nothing suppressed, all kept
+    assert phase_tokens == (0, 0)
+    assert not hasattr(config, "audit_degradations")  # getattr default: no crash, nothing created

--- a/tests/test_audit_debris_cutover.py
+++ b/tests/test_audit_debris_cutover.py
@@ -147,3 +147,26 @@ def test_debris_triage_uses_unified_rubric(temp_dir):
     # V1-5e: the last legacy-prompt holdout flipped onto the unified three-gap
     # rubric, gated by the same-claims A/B in ab-v15e-report.md.
     assert provider.last_system == TRIAGE_SYSTEM_PROMPT
+
+
+def test_provider_failure_records_debris_triage_degradation(temp_dir):
+    """Track 2 PR-A: a Triage-seam failure keeps all findings AND is recorded.
+
+    ``decide_junk_claims`` retries/bisects and swallows a per-chunk provider
+    failure internally (findings come back undecided, verdict=None — see
+    junk_triage.py) so it never raises. To exercise the seam's own
+    ``except Exception`` at the ``_run_phase3_async`` level, the failure has
+    to happen one step earlier: obtaining the runtime itself.
+    """
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    config.audit_degradations = []
+    raw = [_debris("dead_code", "`old_helper` is defined but never used")]
+
+    with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
+        suppressed, phase_tokens = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
+
+    assert suppressed == set()  # best-effort: nothing suppressed, all kept
+    assert phase_tokens == (0, 0)
+    assert config.audit_degradations == [{"phase": "debris-triage", "error": "boom"}]

--- a/tests/test_audit_degradation.py
+++ b/tests/test_audit_degradation.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for observable audit degradation (Track 2 PR-A, work#66 series).
+"""End-to-end tests for observable audit degradation.
 
 The audit orchestrator wraps three best-effort Triage/manifest seams in
 ``except Exception`` (debris-triage, obligations-triage, manifest-write); a
@@ -17,7 +17,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from osoji.audit import format_audit_report, run_audit_async
+from osoji.audit import format_audit_json, format_audit_report, run_audit_async
 from osoji.config import Config
 from osoji.hasher import compute_file_hash, compute_impl_hash
 from osoji.llm.types import CompletionResult, ToolCall
@@ -224,3 +224,15 @@ def test_manifest_write_failure_recorded_without_failing_audit(temp_dir):
     # The manifest is an optimization; its failure must not fail the audit.
     assert result is not None
     assert config.audit_degradations == [{"phase": "manifest-write", "error": "disk full"}]
+
+    # manifest-write runs after the scorecard/report were first built (Phase
+    # 5); its degradation must still reach this run's scorecard and rendered
+    # report, not just config.audit_degradations.
+    assert result.scorecard.degraded_phases == ["manifest-write"]
+
+    report = format_audit_report(result)
+    assert "Triage degradation" in report
+    assert "manifest-write" in report
+
+    json_payload = json.loads(format_audit_json(result))
+    assert json_payload["scorecard"]["degraded_phases"] == ["manifest-write"]

--- a/tests/test_audit_degradation.py
+++ b/tests/test_audit_degradation.py
@@ -1,0 +1,226 @@
+"""End-to-end tests for observable audit degradation (Track 2 PR-A, work#66 series).
+
+The audit orchestrator wraps three best-effort Triage/manifest seams in
+``except Exception`` (debris-triage, obligations-triage, manifest-write); a
+fourth seam (doc-triage) already prints a warning. None of these previously
+recorded anything — a failure there silently degraded the audit to "keep
+everything unverified" with no trace. These tests run the real
+``run_audit_async`` orchestration (mold of ``test_audit_incremental.py``) and
+check the full chain: the failing seam is recorded in
+``config.audit_degradations``, threaded onto ``Scorecard.degraded_phases``,
+and rendered into the markdown report — without changing the underlying
+best-effort behavior (findings are still kept, the audit still completes).
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from osoji.audit import format_audit_report, run_audit_async
+from osoji.config import Config
+from osoji.hasher import compute_file_hash, compute_impl_hash
+from osoji.llm.types import CompletionResult, ToolCall
+
+# --- environment helpers (mold of test_audit_incremental.py) ------------------
+
+
+def _write(temp_dir: Path, rel: str, text: str) -> None:
+    path = temp_dir / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_facts(temp_dir: Path, source: str, string_literals: list[dict]) -> None:
+    facts_file = temp_dir / ".osoji" / "facts" / (source + ".facts.json")
+    facts_file.parent.mkdir(parents=True, exist_ok=True)
+    facts_file.write_text(json.dumps({
+        "source": source,
+        "source_hash": "abc123",
+        "imports": [],
+        "exports": [],
+        "calls": [],
+        "string_literals": string_literals,
+    }), encoding="utf-8")
+
+
+def _one_implicit_contract_env(temp_dir: Path) -> None:
+    _write(temp_dir, "src/producer.py", "def emit():\n    return 'my_category'\n")
+    _write(temp_dir, "src/consumer.py", "def handle(x):\n    return x == 'my_category'\n")
+    _write_facts(temp_dir, "src/producer.py", [
+        {"value": "my_category", "context": "appended to list", "line": 2,
+         "kind": "identifier", "usage": "produced"},
+    ])
+    _write_facts(temp_dir, "src/consumer.py", [
+        {"value": "my_category", "context": "membership check", "line": 2,
+         "kind": "identifier", "usage": "checked"},
+    ])
+
+
+def _write_findings(temp_dir: Path, rel_path: str, findings: list[dict]) -> None:
+    findings_file = temp_dir / ".osoji" / "findings" / (rel_path + ".findings.json")
+    findings_file.parent.mkdir(parents=True, exist_ok=True)
+    source_path = temp_dir / rel_path
+    findings_file.write_text(json.dumps({
+        "source": rel_path,
+        "source_hash": compute_file_hash(source_path),
+        "impl_hash": compute_impl_hash(),
+        "generated": "2026-01-01T00:00:00Z",
+        "findings": findings,
+    }), encoding="utf-8")
+
+
+def _debris_env(temp_dir: Path) -> None:
+    _write(temp_dir, "src/x.py", "def old_helper():\n    pass\n")
+    _write_findings(temp_dir, "src/x.py", [{
+        "category": "dead_code",
+        "line_start": 1,
+        "line_end": 2,
+        "severity": "warning",
+        "description": "`old_helper` is defined but never used",
+    }])
+
+
+class _FakeFacts:
+    """FactsDB stand-in: every symbol has one stable cross-file reference (debris eligibility)."""
+
+    def cross_file_references(self, symbol, source_path):
+        return [{"file": "src/y.py", "kind": "import", "context": "uses it",
+                 "resolves_to_source": True}]
+
+
+class FakeProvider:
+    """Canned submit_triage_verdicts provider; can raise instead (mold of
+    test_audit_incremental.FakeProvider)."""
+
+    def __init__(self, verdicts=None, error=None):
+        self.calls = 0
+        self._verdicts = verdicts
+        self._error = error
+
+    async def complete(self, messages, system, options):
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        verdicts = self._verdicts
+        if verdicts is None:
+            validator = options.tool_input_validators[0]
+            n = len(validator("submit_triage_verdicts", {"verdicts": []}))
+            verdicts = [
+                {"batch_index": i, "verdict": "confirmed", "confidence": 0.9,
+                 "reasoning": "genuine"}
+                for i in range(n)
+            ]
+        return CompletionResult(
+            content=None,
+            tool_calls=[ToolCall(
+                id=f"tc{self.calls}", name="submit_triage_verdicts",
+                input={"verdicts": verdicts},
+            )],
+            input_tokens=140, output_tokens=70,
+            model="test", stop_reason="tool_use",
+        )
+
+    async def close(self):
+        pass
+
+
+_OBLIGATIONS_EXCLUDE = {"shadow", "doc-analysis", "debris"}
+
+
+# --- Phase 3: debris-triage failure --------------------------------------------
+
+
+def test_debris_triage_failure_surfaces_in_scorecard_and_report(temp_dir):
+    # decide_junk_claims retries/bisects and swallows a per-chunk provider
+    # failure internally (findings come back undecided rather than raising —
+    # see junk_triage.py), so a canned erroring provider never reaches the
+    # seam's own except. Failing one step earlier, obtaining the runtime,
+    # exercises it directly.
+    _debris_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+
+    with patch("osoji.facts.FactsDB", return_value=_FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, exclude={"shadow", "doc-analysis"},
+        ))
+
+    # Best-effort: the debris finding is still kept (unverified), not dropped.
+    debris_issues = [i for i in result.issues if i.exclude_key == "debris"]
+    assert len(debris_issues) == 1
+
+    assert config.audit_degradations == [{"phase": "debris-triage", "error": "boom"}]
+    assert result.scorecard.degraded_phases == ["debris-triage"]
+
+    report = format_audit_report(result)
+    assert "Triage degradation" in report
+    assert "debris-triage" in report
+
+
+# --- Phase 3.5: obligations-triage failure -------------------------------------
+
+
+def test_obligations_triage_failure_surfaces_in_scorecard_and_report(temp_dir):
+    # Same rationale as the debris-triage test above: fail create_runtime
+    # itself rather than the provider's complete(), since decide_junk_claims
+    # absorbs a per-chunk provider failure without raising.
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+
+    with patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+        ))
+
+    # Best-effort: the heuristic obligation finding is still kept, unverified.
+    obligation_issues = [i for i in result.issues if i.exclude_key == "obligations"]
+    assert len(obligation_issues) == 1
+
+    assert config.audit_degradations == [{"phase": "obligations-triage", "error": "boom"}]
+    assert result.scorecard.degraded_phases == ["obligations-triage"]
+
+    report = format_audit_report(result)
+    assert "Triage degradation" in report
+    assert "obligations-triage" in report
+
+
+# --- no degradation: the baseline stays clean ----------------------------------
+
+
+def test_no_degradation_run_reports_none(temp_dir):
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = FakeProvider()  # succeeds
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+        ))
+
+    assert config.audit_degradations == []
+    assert result.scorecard.degraded_phases is None
+
+    report = format_audit_report(result)
+    assert "Triage degradation" in report
+    assert "none" in report
+
+
+# --- V1-9 manifest-write failure ------------------------------------------------
+
+
+def test_manifest_write_failure_recorded_without_failing_audit(temp_dir):
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = FakeProvider()  # obligations triage succeeds; only the manifest write fails
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())), \
+         patch("osoji.audit.write_manifest", side_effect=RuntimeError("disk full")):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+        ))
+
+    # The manifest is an optimization; its failure must not fail the audit.
+    assert result is not None
+    assert config.audit_degradations == [{"phase": "manifest-write", "error": "disk full"}]

--- a/tests/test_audit_obligations_cutover.py
+++ b/tests/test_audit_obligations_cutover.py
@@ -215,7 +215,7 @@ def test_provider_failure_keeps_findings_unverified(temp_dir):
 
 
 def test_provider_failure_records_obligations_triage_degradation(temp_dir):
-    """Track 2 PR-A: a Triage-seam failure keeps findings AND is recorded.
+    """A Triage-seam failure keeps findings AND is recorded.
 
     Mirrors the debris-triage seam's degradation contract. ``decide_junk_claims``
     swallows a per-chunk provider failure internally (see

--- a/tests/test_audit_obligations_cutover.py
+++ b/tests/test_audit_obligations_cutover.py
@@ -214,6 +214,29 @@ def test_provider_failure_keeps_findings_unverified(temp_dir):
     assert (triaged, other) == (0, 0)
 
 
+def test_provider_failure_records_obligations_triage_degradation(temp_dir):
+    """Track 2 PR-A: a Triage-seam failure keeps findings AND is recorded.
+
+    Mirrors the debris-triage seam's degradation contract. ``decide_junk_claims``
+    swallows a per-chunk provider failure internally (see
+    test_audit_debris_cutover.py's equivalent test for why), so the seam's own
+    ``except Exception`` at the ``_run_phase3_5_async`` level is exercised by
+    failing one step earlier: obtaining the runtime itself.
+    """
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    config.audit_degradations = []
+
+    with patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
+        findings, _tokens, triaged, other = asyncio.run(
+            _run_phase3_5_async(config, True, MagicMock(), False)
+        )
+
+    assert len(findings) == 1  # best-effort: kept, unverified
+    assert (triaged, other) == (0, 0)
+    assert config.audit_degradations == [{"phase": "obligations-triage", "error": "boom"}]
+
+
 def test_claim_call_uses_unified_triage_prompt(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[

--- a/tests/test_doc_analysis_cutover.py
+++ b/tests/test_doc_analysis_cutover.py
@@ -247,7 +247,7 @@ class _FakeAnalyzeProvider:
 
 @pytest.mark.asyncio
 async def test_triage_post_pass_failure_records_doc_triage_degradation(temp_dir):
-    """Track 2 PR-A: the Triage post-pass already prints a warning on failure
+    """The Triage post-pass already prints a warning on failure
     (analyze_docs_async, doc_analysis.py); it must also record the
     degradation via config.audit_degradations so the run can surface it."""
     _write(temp_dir, "README.md", "# Project\n")

--- a/tests/test_doc_analysis_cutover.py
+++ b/tests/test_doc_analysis_cutover.py
@@ -18,12 +18,19 @@ migration must preserve or deliberately change.
 """
 
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from osoji import doc_analysis
 from osoji.claim_builder import CLAIM_BUILDER_SCHEMA, build_claims, category_of
 from osoji.config import Config
-from osoji.doc_analysis import DocAnalysisResult, DocFinding, _triage_doc_findings
+from osoji.doc_analysis import (
+    DocAnalysisResult,
+    DocFinding,
+    _triage_doc_findings,
+    analyze_docs_async,
+)
 from osoji.evidence_builders import BuildContext
 from osoji.findings_adapter import finding_from_doc, gap_type_for
 from osoji.llm.types import CompletionResult, ToolCall
@@ -213,6 +220,47 @@ async def test_debris_result_findings_are_not_triaged(temp_dir):
 
     assert provider.calls == 0
     assert len(result.findings) == 1  # untouched
+
+
+class _FakeAnalyzeProvider:
+    """Canned analyze_document provider. No directory shadow docs are present,
+    so the topic-matching tier short-circuits before ever calling complete()."""
+
+    async def complete(self, messages, system, options):
+        return CompletionResult(
+            content=None,
+            tool_calls=[ToolCall(
+                id="tc1", name="analyze_document",
+                input={
+                    "classification": "reference",
+                    "confidence": 0.9,
+                    "classification_reason": "doc",
+                    "findings": [],
+                },
+            )],
+            input_tokens=10, output_tokens=5, model="test", stop_reason="tool_use",
+        )
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_triage_post_pass_failure_records_doc_triage_degradation(temp_dir):
+    """Track 2 PR-A: the Triage post-pass already prints a warning on failure
+    (analyze_docs_async, doc_analysis.py); it must also record the
+    degradation via config.audit_degradations so the run can surface it."""
+    _write(temp_dir, "README.md", "# Project\n")
+    (temp_dir / ".osoji" / "shadow").mkdir(parents=True, exist_ok=True)
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    config.audit_degradations = []
+    provider = _FakeAnalyzeProvider()
+
+    with patch.object(doc_analysis, "_triage_doc_findings", AsyncMock(side_effect=RuntimeError("boom"))):
+        results = await analyze_docs_async(provider, config)
+
+    assert len(results) == 1  # the per-doc analysis itself still succeeded
+    assert config.audit_degradations == [{"phase": "doc-triage", "error": "boom"}]
 
 
 @pytest.mark.asyncio

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -381,12 +381,12 @@ def test_bundle_doc_analysis_empty_when_no_docs(temp_dir):
     assert bundle["doc_analysis"] == {}
 
 
-def test_bundle_schema_version_is_1_2_0(temp_dir):
+def test_bundle_schema_version_is_1_3_0(temp_dir):
     _write_source(temp_dir, "main.py", "x = 1\n")
 
     bundle = build_observatory_bundle(temp_dir, respect_gitignore=False)
 
-    assert bundle["schema_version"] == "1.2.0"
+    assert bundle["schema_version"] == "1.3.0"
 
 
 def test_export_command_writes_bundle_file(temp_dir):


### PR DESCRIPTION
## What

The audit orchestrator wraps four best-effort triage seams (debris triage, obligations triage, doc triage, verdict-manifest write) in catch-all handlers so a triage failure never loses findings. Previously those handlers were silent: a failure degraded the audit to \"keep everything unverified\" with no trace. This PR makes degradation observable without changing failure behavior:

- Each seam records `{phase, error}` into a per-run `config.audit_degradations` list (same attach-pattern as the verdict session) and emits a `[warn] <phase> failed; findings kept unverified: <exc>` line.
- New `Scorecard.degraded_phases: list[str] | None` persists the phase labels; the report gains a `Triage degradation:` summary row; JSON output inherits the field.
- Because the manifest write is the last seam, the scorecard and audit result are re-serialized after it (mirroring the existing doc-prompts re-serialize) so a manifest-write failure is visible in its own run's artifacts.

## Observatory schema

`degraded_phases` is mirrored into `$defs.Scorecard` in `osoji-observatory.schema.json`; bundle version 1.2.0 -> 1.3.0. **osoji-teams coordination**: the ingest API/dashboard should tolerate the new optional field before this ships in a release.

## Known remaining gap (follow-up candidate)

Per-chunk provider failures inside `decide_junk_claims` are absorbed by its bisect/retry (findings surface with `verdict=None`) and do not reach these phase-level counters. Extending degradation recording to chunk granularity is a separate change.

## Verification

- New `tests/test_audit_degradation.py` exercises all four seams through the real `run_audit_async` orchestration: findings kept on failure, phases recorded, report row and JSON both rendered; plus a no-degradation run, serialize/load round-trip, and the getattr-absent safety path.
- Full deterministic suite: 1204 passed, 10 skipped. Schema/dataclass parity test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)