### PR TITLE
Security: raise pyasn1 floor to 0.6.4 (CVE-2026-59885/59886)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "click>=8.3.3",  # floor excludes PYSEC-2026-2132 (command injection in click.edit)
     "google-genai>=1.10.0",
     "openai>=1.75.0",
+    "pyasn1>=0.6.4",  # transitive via google-auth; floor excludes CVE-2026-59885/59886
     "python-dotenv>=1.0.0",
     "tabulate>=0.9.0",
     "tree-sitter>=0.25,<0.27",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -586,10 +586,12 @@ pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
     # via pytest
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
-    # via pyasn1-modules
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+    # via
+    #   osojicode (pyproject.toml)
+    #   pyasn1-modules
 pyasn1-modules==0.4.2 \
     --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a \
     --hash=sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6

--- a/requirements.lock
+++ b/requirements.lock
@@ -449,10 +449,12 @@ openai==2.30.0 \
     --hash=sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885 \
     --hash=sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d
     # via osojicode (pyproject.toml)
-pyasn1==0.6.3 \
-    --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
-    --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
-    # via pyasn1-modules
+pyasn1==0.6.4 \
+    --hash=sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81 \
+    --hash=sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b
+    # via
+    #   osojicode (pyproject.toml)
+    #   pyasn1-modules
 pyasn1-modules==0.4.2 \
     --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a \
     --hash=sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6


### PR DESCRIPTION
## Trigger

The `audit` CI job on #135 failed at 2026-07-21 19:36 UTC: pip-audit flagged `pyasn1 0.6.3` for CVE-2026-59885 and CVE-2026-59886 (both fixed in 0.6.4). This gate blocks all PRs until resolved.

## Triage

- **Affected**: both `requirements.lock` and `requirements-dev.lock` pinned `pyasn1==0.6.3` (hash-verified); local dev envs likewise.
- pyasn1 is **transitive**: `google-genai → google-auth → pyasn1-modules → pyasn1`; pinned at 0.6.3 since the litellm→direct-SDK refactor (#66, 2026-04-26).
- **No released version affected**: latest release v0.2.0 (2026-03-23) predates the pin, and published dists carry only `pyproject.toml` floors, not lock pins — fresh installs resolve to 0.6.4+.

## Fix

Same mechanism as the click remediation (#131): a version floor in `pyproject.toml` with rationale comment (`pyasn1>=0.6.4`, transitive floor), both lock files regenerated per the documented workflow (`uv pip compile … --generate-hashes --universal`, runtime + dev).

## Verification

- `pip-audit -r requirements.lock` and `-r requirements-dev.lock`: **No known vulnerabilities found** (both).
- Both locks now pin `pyasn1==0.6.4`; diff is minimal (floor line + version/hashes/via annotations).
- Full deterministic test suite on the branch: 1191 passed, 10 skipped.

## Detection review (post-mortem)

Detection pattern repeats the 2026-07-15 click incident exactly: **Dependabot silent** (no pyasn1 alert — advisory apparently not GitHub-reviewed), **scheduled security scan blind** (weekly cadence; last ran 2026-07-15, green, before the advisory), **merge-time pip-audit caught it**. Two incidents in six days with the same pattern; the merge gate is doing all the work. Follow-up filed to consider a daily scan cadence.

## After merge

PRs opened before this fix (currently #135) need their branches updated (merge main) to re-run the audit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)