### PR TITLE
surface Triage outputs at the AuditIssue/report/JSON boundary

### DIFF
--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from .config import Config, SHADOW_DIR
 from .diff import get_diff_files
+from .findings import Finding
 from .hasher import is_findings_current
 from .hooks import find_git_root
 from .junk import JunkAnalyzer, JunkAnalysisResult, load_shadow_content
@@ -112,6 +113,16 @@ class AuditIssue:
     origin: dict | None = None  # {"source": "llm"|"static"|"hybrid", "plugin": str}
     exclude_key: str | None = None  # matches --exclude identifier for this phase
     contract_class: str | None = None  # obligations only: string-contract taxonomy class (V1-5c)
+    # Triage outputs, threaded from the decided Finding when one exists.
+    # Additive: the detector's heuristic `remediation` above is unchanged; these
+    # ride alongside it. None whenever no decided Finding backs this issue
+    # (Triage never ran for this phase, or the seam degraded — see
+    # audit_manifest.py's VerdictSession for the same vocabulary).
+    finding_id: str | None = None
+    verdict: str | None = None
+    confidence: float | None = None
+    triage_reasoning: str | None = None
+    suggested_fix: str | None = None
 
 
 @dataclass
@@ -279,6 +290,8 @@ def _serialize_junk_results(config: Config, analyzer_name: str, result: JunkAnal
             "remediation": item.remediation,
             "original_purpose": item.original_purpose,
             "metadata": item.metadata,
+            "finding_id": item.finding_id,
+            "verdict": item.verdict,
         })
     for source_path, findings in by_source.items():
         out_path = config.analysis_junk_path_for(analyzer_name, Path(source_path))
@@ -459,7 +472,7 @@ async def run_audit_async(
         return [], (0, 0)
 
     async def _noop_phase3():
-        return set(), (0, 0)
+        return set(), (0, 0), {}
 
     async def _noop_phase4():
         return {}, {}
@@ -477,7 +490,7 @@ async def run_audit_async(
         await asyncio.gather(phase2_coro, phase3_coro, phase3_5_coro, phase4_coro)
     )
     analysis_results, phase2_tokens = phase2_raw
-    debris_result, phase3_tokens = phase3_raw
+    debris_result, phase3_tokens, debris_decided = phase3_raw
     obligation_findings, phase3_5_tokens, contract_triaged, contract_other = phase3_5_raw
     junk_results, phase4_tokens = phase4_raw
 
@@ -507,6 +520,11 @@ async def run_audit_async(
                 remediation=finding.remediation,
                 origin={"source": "llm", "plugin": "doc_analysis"},
                 exclude_key="doc-analysis",
+                finding_id=finding.finding_id,
+                verdict=finding.verdict,
+                confidence=finding.confidence,
+                triage_reasoning=finding.triage_reasoning,
+                suggested_fix=finding.suggested_fix,
             ))
 
     # Serialize Phase 2 results
@@ -526,11 +544,13 @@ async def run_audit_async(
                     "shadow_ref": f.shadow_ref,
                     "evidence": f.evidence,
                     "remediation": f.remediation,
-                    # Unified-Triage outputs (V1-5d); additive, may be None when
-                    # a finding passed through unverified.
+                    # Unified-Triage outputs; additive, may be None when a
+                    # finding passed through unverified.
                     "verdict": f.verdict,
                     "confidence": f.confidence,
                     "triage_reasoning": f.triage_reasoning,
+                    "suggested_fix": f.suggested_fix,
+                    "finding_id": f.finding_id,
                 }
                 for f in item.findings
             ],
@@ -542,9 +562,16 @@ async def run_audit_async(
     for i, finding in enumerate(raw_debris):
         if i in suppressed_indices:
             continue
+        # Triage overlay (additive): a decided Finding (when one exists for
+        # this raw index) contributes its verdict/confidence/reasoning/
+        # suggested-fix, plus a severity re-grade (Triage may demote a real
+        # finding to a lower severity, never drop it outright) — the heuristic
+        # severity/remediation stay the fallback, never dropped.
+        decided = debris_decided.get(i)
+        heuristic_severity = finding["severity"]
         issues.append(AuditIssue(
             path=finding["source_path"],
-            severity=finding["severity"],
+            severity=(decided.severity or heuristic_severity) if decided is not None else heuristic_severity,
             category=finding["category"],
             message=f"L{finding['line_start']}-{finding['line_end']}: {finding['description']}",
             remediation=finding.get("suggestion", "Review and fix the identified issue"),
@@ -552,6 +579,11 @@ async def run_audit_async(
             line_end=finding["line_end"],
             origin={"source": "llm", "plugin": "code_debris"},
             exclude_key="debris",
+            finding_id=decided.id if decided is not None else None,
+            verdict=decided.verdict if decided is not None else None,
+            confidence=decided.confidence if decided is not None else None,
+            triage_reasoning=decided.triage_reasoning if decided is not None else None,
+            suggested_fix=decided.suggested_fix if decided is not None else None,
         ))
 
     # Collect issues from Phase 3.5 (obligations)
@@ -565,6 +597,11 @@ async def run_audit_async(
             origin={"source": "hybrid", "plugin": "obligations"},
             exclude_key="obligations",
             contract_class=f.contract_class,
+            finding_id=f.finding_id,
+            verdict=f.verdict,
+            confidence=f.triage_confidence,
+            triage_reasoning=f.triage_reasoning,
+            suggested_fix=f.suggested_fix,
         ))
 
     # Collect issues from Phase 4 (junk analyzers)
@@ -583,6 +620,11 @@ async def run_audit_async(
                 line_end=item.line_end,
                 origin={"source": origin_source, "plugin": analyzer_name},
                 exclude_key=junk_exclude_key,
+                finding_id=item.finding_id,
+                verdict=item.verdict,
+                confidence=item.confidence,
+                triage_reasoning=item.reason,
+                suggested_fix=item.remediation,
             ))
         _serialize_junk_results(config, analyzer_name, junk_result)
 
@@ -792,11 +834,18 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
     ``dismissed`` verdict suppresses the finding — preserving the prior behavior
     where a confirmed-false-positive was dropped. Best-effort: on any failure
     all findings are kept.
+
+    Returns ``(suppressed_indices, phase_tokens, decided_by_index)``: the third
+    element maps each eligible raw-debris index to its decided ``Finding``, so
+    the caller can overlay verdict/confidence/reasoning/suggested-fix/severity
+    onto the corresponding kept ``AuditIssue`` (additive; empty on any failure
+    or when nothing needed verification).
     """
     from .junk_triage import decide_junk_claims
     _emit(config, "Osoji: Checking code debris findings...")
     phase_start = time_module.monotonic()
     suppressed_indices: set[int] = set()
+    decided_by_index: dict[int, Finding] = {}
     phase_tokens = (0, 0)
     needs_verification = any(_is_eligible(f) for f in raw_debris)
     if needs_verification:
@@ -813,6 +862,7 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
                 finally:
                     await provider.close()
                 for finding, orig_idx in zip(decided, original_indices):
+                    decided_by_index[orig_idx] = finding
                     if finding.verdict == "dismissed":
                         suppressed_indices.add(orig_idx)
                 phase_tokens = (in_tok, out_tok)
@@ -838,19 +888,32 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
         _emit(config, f"  [phase 3 debris triage: {elapsed:.1f}s] {tok_str}")
     elif verbose:
         _emit(config, f"  [phase 3 debris triage: {elapsed:.1f}s]")
-    return suppressed_indices, phase_tokens
+    return suppressed_indices, phase_tokens, decided_by_index
 
 
 def _overlay_verdict(cf, decided):
-    """Record the Triage verdict's string-contract class on a ContractFinding.
+    """Record the Triage verdict's outputs on a ContractFinding, additively.
 
-    Only ``contract_class`` is overlaid; severity/remediation/confidence stay
-    heuristic. Two reasons: signal conservation (Triage's confirm/dismiss is the
-    single variable this migration changes — it must not *also* re-scale the
-    heuristic priors), and the heuristic remediation already carries the
+    ``contract_class`` plus the raw verdict/confidence/reasoning/suggested-fix
+    and the decided Finding's id now ride along on new optional fields
+    (``verdict``, ``triage_confidence``, ``triage_reasoning``, ``suggested_fix``,
+    ``finding_id``) so the product boundary can surface what Triage decided.
+
+    ``severity``/``remediation``/``confidence`` stay heuristic — untouched by
+    this overlay. Two reasons: signal conservation (Triage's confirm/dismiss is
+    the single variable this migration changes — it must not *also* re-scale
+    the heuristic priors), and the heuristic remediation already carries the
     silent-value / loud-name framing the constraint requires preserved.
     """
-    return replace(cf, contract_class=decided.contract_class)
+    return replace(
+        cf,
+        contract_class=decided.contract_class,
+        finding_id=decided.id,
+        verdict=decided.verdict,
+        triage_confidence=decided.confidence,
+        triage_reasoning=decided.triage_reasoning,
+        suggested_fix=decided.suggested_fix,
+    )
 
 
 async def _run_phase3_5_async(config, obligations_enabled, rate_limiter, verbose):
@@ -1008,6 +1071,11 @@ def load_audit_result(config: Config) -> AuditResult:
             origin=i.get("origin"),
             exclude_key=i.get("exclude_key"),
             contract_class=i.get("contract_class"),
+            finding_id=i.get("finding_id"),
+            verdict=i.get("verdict"),
+            confidence=i.get("confidence"),
+            triage_reasoning=i.get("triage_reasoning"),
+            suggested_fix=i.get("suggested_fix"),
         )
         for i in data.get("issues", [])
     ]
@@ -1290,6 +1358,14 @@ def format_audit_report(result: AuditResult) -> str:
             lines.append(f"**Category**: {issue.category}")
             lines.append(f"**Issue**: {issue.message}")
             lines.append(f"**Remediation**: {issue.remediation}")
+            if issue.suggested_fix:
+                meta = []
+                if issue.verdict is not None:
+                    meta.append(issue.verdict)
+                if issue.confidence is not None:
+                    meta.append(f"{issue.confidence:.2f}")
+                meta_tag = f" ({', '.join(meta)})" if meta else ""
+                lines.append(f"**Suggested fix (triage)**: {issue.suggested_fix}{meta_tag}")
             lines.append("")
 
     if warnings:
@@ -1351,6 +1427,11 @@ def format_audit_json(result: AuditResult) -> str:
                 **({"origin": issue.origin} if issue.origin else {}),
                 **({"exclude_key": issue.exclude_key} if issue.exclude_key else {}),
                 **({"contract_class": issue.contract_class} if issue.contract_class else {}),
+                **({"finding_id": issue.finding_id} if issue.finding_id else {}),
+                **({"verdict": issue.verdict} if issue.verdict else {}),
+                **({"confidence": issue.confidence} if issue.confidence is not None else {}),
+                **({"triage_reasoning": issue.triage_reasoning} if issue.triage_reasoning else {}),
+                **({"suggested_fix": issue.suggested_fix} if issue.suggested_fix else {}),
             }
             for issue in result.issues
         ],
@@ -2005,7 +2086,13 @@ def _html_accuracy_section(result: "AuditResult") -> str:
         parts.append(f'<p style="font-weight:400;color:var(--text-1);margin-top:12px">{_h(cat)}</p>')
         parts.append('<ul class="file-list">')
         for issue in by_cat[cat]:
-            parts.append(f'<li>{_h(str(issue.path))}{_issue_loc(issue)}: {_h(issue.message)}</li>')
+            fix_tag = ""
+            if issue.suggested_fix:
+                fix_tag = (
+                    f'<br><span style="color:var(--text-3)">'
+                    f'Suggested fix (triage): {_h(issue.suggested_fix)}</span>'
+                )
+            parts.append(f'<li>{_h(str(issue.path))}{_issue_loc(issue)}: {_h(issue.message)}{fix_tag}</li>')
         parts.append('</ul>')
 
     parts.append('</div></div>')

--- a/src/osoji/deadcode.py
+++ b/src/osoji/deadcode.py
@@ -694,6 +694,8 @@ class DeadCodeAnalyzer(JunkAnalyzer):
                 confidence_source=(
                     "ast_proven" if (f.path, name) in mechanical_keys else "llm_inferred"
                 ),
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/src/osoji/deadparam.py
+++ b/src/osoji/deadparam.py
@@ -341,6 +341,8 @@ class DeadParameterAnalyzer(JunkAnalyzer):
                 # gated_lines died with the per-detector verify tool: the
                 # unified verdict schema carries no detector-specific fields.
                 metadata={"function_name": function_name, "gated_lines": []},
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/src/osoji/doc_analysis.py
+++ b/src/osoji/doc_analysis.py
@@ -50,6 +50,10 @@ class DocFinding:
     verdict: str | None = None
     confidence: float | None = None
     triage_reasoning: str | None = None
+    # Also additive — the decided Finding's suggested remediation and stable
+    # id, threaded through to the product boundary alongside the above.
+    suggested_fix: str | None = None
+    finding_id: str | None = None
 
 
 @dataclass
@@ -647,6 +651,8 @@ async def _triage_doc_findings(
         df.verdict = fnd.verdict
         df.confidence = fnd.confidence
         df.triage_reasoning = fnd.triage_reasoning
+        df.suggested_fix = fnd.suggested_fix
+        df.finding_id = fnd.id
         if fnd.verdict == "uncertain":
             df.severity = "warning"                  # kept, but downgraded (signal conservation)
         elif fnd.severity:

--- a/src/osoji/junk.py
+++ b/src/osoji/junk.py
@@ -31,6 +31,13 @@ class JunkFinding:
     original_purpose: str     # what the item was for
     confidence_source: str = "llm_inferred"  # "ast_proven" | "llm_inferred" | "heuristic"
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Triage outputs: threaded from the decided Finding, additive.
+    # ``reason``/``remediation``/``confidence`` above already carry the decided
+    # Finding's triage_reasoning/suggested_fix/confidence (see each analyzer's
+    # mapping) — these two are the only ones still missing at the product
+    # boundary.
+    finding_id: str | None = None
+    verdict: str | None = None
 
     def __post_init__(self) -> None:
         if self.line_end is not None and self.line_end < self.line_start:

--- a/src/osoji/junk_cicd.py
+++ b/src/osoji/junk_cicd.py
@@ -650,6 +650,8 @@ class DeadCICDAnalyzer(JunkAnalyzer):
                 remediation=f.suggested_fix or f"Remove {element_type} `{element_name}`",
                 original_purpose=f"{element_type} `{element_name}`",
                 confidence_source="llm_inferred",
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/src/osoji/junk_deps.py
+++ b/src/osoji/junk_deps.py
@@ -807,6 +807,8 @@ class DeadDepsAnalyzer(JunkAnalyzer):
                 # usage_type died with the verify verdict; a confirmed finding is
                 # unused by definition, preserving the downstream key.
                 metadata={"usage_type": "unused"},
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/src/osoji/junk_orphan.py
+++ b/src/osoji/junk_orphan.py
@@ -469,6 +469,8 @@ class OrphanedFilesAnalyzer(JunkAnalyzer):
                 remediation=f.suggested_fix or "Delete file",
                 original_purpose=f"file `{f.path}`",
                 confidence_source="llm_inferred",
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/src/osoji/obligations.py
+++ b/src/osoji/obligations.py
@@ -58,6 +58,16 @@ class ContractFinding:
     # Filled by unified Triage (V1-5c) when the finding is routed through
     # Phase 3.5; one of the string-contract taxonomy classes or "other".
     contract_class: str | None = None
+    # Triage outputs, threaded onto the product boundary additively.
+    # ``severity``/``confidence``/``remediation`` above stay heuristic (see
+    # ``_overlay_verdict``'s docstring); ``triage_confidence`` is a distinct
+    # field precisely so it does not collide with — or get sorted/weighted by
+    # — the pre-existing heuristic ``confidence``.
+    finding_id: str | None = None
+    verdict: str | None = None
+    triage_confidence: float | None = None
+    triage_reasoning: str | None = None
+    suggested_fix: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/osoji/plumbing.py
+++ b/src/osoji/plumbing.py
@@ -233,6 +233,8 @@ class DeadPlumbingAnalyzer(JunkAnalyzer):
                 # trace drew on the deleted verify tool's separate `trace` field;
                 # the unified verdict carries reasoning instead.
                 metadata={"schema_name": schema_name, "trace": f.triage_reasoning or ""},
+                finding_id=f.id,
+                verdict=f.verdict,
             ))
         return JunkAnalysisResult(
             findings=findings,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,5 +1,6 @@
 """Tests for audit result formatting, serialization, and scorecard construction."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -11,10 +12,14 @@ from osoji.audit import (
     _format_scorecard_section,
     _infer_variable_type,
     _lookup_type_definitions,
+    _serialize_junk_results,
     format_audit_html,
+    format_audit_json,
+    format_audit_report,
     serialize_audit_result,
     load_audit_result,
 )
+from osoji.junk import JunkAnalysisResult, JunkFinding
 from osoji.scorecard import CoverageEntry, JunkCodeEntry, Scorecard
 
 
@@ -642,6 +647,185 @@ class TestAuditResultRoundTrip:
         loaded = load_audit_result(config)
 
         assert loaded.scorecard.degraded_phases is None
+
+    def test_triage_fields_round_trip(self, temp_dir):
+        """The five Triage-output fields survive serialize -> load."""
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        original = AuditResult(
+            issues=[
+                AuditIssue(
+                    path=Path("src/x.py"),
+                    severity="error",
+                    category="debris",
+                    message="dead code",
+                    remediation="remove it",
+                    finding_id="abc123",
+                    verdict="confirmed",
+                    confidence=0.87,
+                    triage_reasoning="cross-file sweep found no references",
+                    suggested_fix="delete lines 10-12",
+                ),
+                AuditIssue(
+                    path=Path("src/y.py"),
+                    severity="warning",
+                    category="stale_shadow",
+                    message="stale",
+                    remediation="update",
+                ),
+            ],
+            scorecard=_minimal_scorecard(),
+        )
+
+        serialize_audit_result(config, original)
+        loaded = load_audit_result(config)
+
+        triaged = loaded.issues[0]
+        assert triaged.finding_id == "abc123"
+        assert triaged.verdict == "confirmed"
+        assert triaged.confidence == pytest.approx(0.87)
+        assert triaged.triage_reasoning == "cross-file sweep found no references"
+        assert triaged.suggested_fix == "delete lines 10-12"
+
+        untriaged = loaded.issues[1]
+        assert untriaged.finding_id is None
+        assert untriaged.verdict is None
+        assert untriaged.confidence is None
+        assert untriaged.triage_reasoning is None
+        assert untriaged.suggested_fix is None
+
+
+class TestTriageFieldsInJSON:
+    """format_audit_json follows the existing origin omit-if-None idiom."""
+
+    def test_present_fields_are_emitted(self):
+        result = AuditResult(issues=[
+            AuditIssue(
+                path=Path("src/x.py"), severity="error", category="debris",
+                message="dead code", remediation="remove it",
+                finding_id="abc123", verdict="confirmed", confidence=0.87,
+                triage_reasoning="no references found", suggested_fix="delete lines 10-12",
+            ),
+        ])
+
+        payload = json.loads(format_audit_json(result))
+
+        issue = payload["issues"][0]
+        assert issue["finding_id"] == "abc123"
+        assert issue["verdict"] == "confirmed"
+        assert issue["confidence"] == pytest.approx(0.87)
+        assert issue["triage_reasoning"] == "no references found"
+        assert issue["suggested_fix"] == "delete lines 10-12"
+
+    def test_absent_fields_are_omitted(self):
+        result = AuditResult(issues=[
+            AuditIssue(
+                path=Path("src/y.py"), severity="warning", category="stale_shadow",
+                message="stale", remediation="update",
+            ),
+        ])
+
+        payload = json.loads(format_audit_json(result))
+
+        issue = payload["issues"][0]
+        for key in ("finding_id", "verdict", "confidence", "triage_reasoning", "suggested_fix"):
+            assert key not in issue
+
+    def test_zero_confidence_is_not_treated_as_absent(self):
+        """A real (if unusual) 0.0 triage confidence must not be omitted like None."""
+        result = AuditResult(issues=[
+            AuditIssue(
+                path=Path("src/z.py"), severity="warning", category="debris",
+                message="m", remediation="r", verdict="uncertain", confidence=0.0,
+            ),
+        ])
+
+        payload = json.loads(format_audit_json(result))
+
+        assert payload["issues"][0]["confidence"] == 0.0
+
+
+class TestErrorReportSuggestedFix:
+    """The Errors (blocking) markdown section surfaces the Triage suggested fix."""
+
+    def test_suggested_fix_line_present_with_verdict_and_confidence(self):
+        result = AuditResult(issues=[
+            AuditIssue(
+                path=Path("src/x.py"), severity="error", category="debris",
+                message="dead code", remediation="remove it",
+                verdict="confirmed", confidence=0.87, suggested_fix="delete lines 10-12",
+            ),
+        ])
+
+        report = format_audit_report(result)
+
+        assert "**Suggested fix (triage)**: delete lines 10-12" in report
+        assert "confirmed" in report
+        assert "0.87" in report
+
+    def test_suggested_fix_line_absent_when_not_present(self):
+        result = AuditResult(issues=[
+            AuditIssue(
+                path=Path("src/x.py"), severity="error", category="debris",
+                message="dead code", remediation="remove it",
+            ),
+        ])
+
+        report = format_audit_report(result)
+
+        assert "Suggested fix (triage)" not in report
+
+    def test_html_report_shows_suggested_fix_on_doc_errors(self):
+        scorecard = _minimal_scorecard(
+            accuracy_by_category={"doc_stale_content": 1},
+            total_accuracy_errors=1, live_doc_count=1, accuracy_errors_per_doc=1.0,
+        )
+        result = AuditResult(
+            issues=[
+                AuditIssue(
+                    path=Path("README.md"), severity="error", category="doc_stale_content",
+                    message="doc says X", remediation="update the doc",
+                    suggested_fix="change X to Y in the README",
+                ),
+            ],
+            scorecard=scorecard,
+        )
+
+        html = format_audit_html(result)
+
+        assert "Suggested fix (triage)" in html
+        assert "change X to Y in the README" in html
+
+
+class TestJunkResultsSerializeFindingIdAndVerdict:
+    """_serialize_junk_results additively carries finding_id/verdict."""
+
+    def test_finding_id_and_verdict_serialized(self, temp_dir):
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        result = JunkAnalysisResult(
+            findings=[
+                JunkFinding(
+                    source_path="src/utils.py", name="old_func", kind="function",
+                    category="dead_symbol", line_start=10, line_end=20,
+                    confidence=0.9, reason="no references", remediation="remove it",
+                    original_purpose="function `old_func`",
+                    finding_id="abc123", verdict="confirmed",
+                ),
+            ],
+            total_candidates=1,
+            analyzer_name="dead_code",
+        )
+
+        _serialize_junk_results(config, "dead_code", result)
+
+        out_path = config.analysis_junk_path_for("dead_code", Path("src/utils.py"))
+        payload = json.loads(out_path.read_text(encoding="utf-8"))
+
+        assert payload["findings"][0]["finding_id"] == "abc123"
+        assert payload["findings"][0]["verdict"] == "confirmed"
 
 
 # --- Debris symbol extraction ---

--- a/tests/test_audit_debris_cutover.py
+++ b/tests/test_audit_debris_cutover.py
@@ -10,11 +10,13 @@ unified rubric (the legacy debris prompt is retired; A/B in ab-v15e-report.md).
 """
 
 import asyncio
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from osoji.audit import _run_phase3_async
+from osoji.audit import _run_phase3_async, run_audit_async
 from osoji.config import Config
+from osoji.hasher import compute_file_hash, compute_impl_hash
 from osoji.llm.types import CompletionResult, ToolCall
 from osoji.triage import TRIAGE_SYSTEM_PROMPT
 
@@ -86,13 +88,19 @@ def test_dismissed_verdicts_suppress_correct_indices(temp_dir):
         {"batch_index": 1, "verdict": "confirmed", "confidence": 0.8, "reasoning": "real bug"},
     ]))
 
-    suppressed, phase_tokens = _run(config, raw, provider)
+    suppressed, phase_tokens, decided = _run(config, raw, provider)
 
     # Only the dismissed dead_code finding (raw index 0) is suppressed;
     # the ineligible block (1) and the confirmed latent_bug (2) are kept.
     assert suppressed == {0}
     assert phase_tokens == (120, 60)
     assert provider.calls == 1
+    # Both eligible claims land in the decided map, keyed by raw index.
+    assert set(decided.keys()) == {0, 2}
+    assert decided[0].verdict == "dismissed"
+    assert decided[2].verdict == "confirmed"
+    assert decided[2].confidence == 0.8
+    assert decided[2].triage_reasoning == "real bug"
 
 
 def test_ineligible_only_makes_no_llm_call(temp_dir):
@@ -103,11 +111,12 @@ def test_ineligible_only_makes_no_llm_call(temp_dir):
     ]
     provider = FakeProvider(_verdicts_result([]))
 
-    suppressed, phase_tokens = _run(config, raw, provider)
+    suppressed, phase_tokens, decided = _run(config, raw, provider)
 
     assert suppressed == set()
     assert phase_tokens == (0, 0)
     assert provider.calls == 0
+    assert decided == {}
 
 
 def test_debris_corpus_is_decided_in_bounded_chunks(temp_dir):
@@ -128,11 +137,12 @@ def test_debris_corpus_is_decided_in_bounded_chunks(temp_dir):
            for i in range(1, 12)]
     ))
 
-    suppressed, phase_tokens = _run(config, raw, provider)
+    suppressed, phase_tokens, decided = _run(config, raw, provider)
 
     assert provider.calls == 2  # 13 claims → chunks of 12 + 1
     assert suppressed == {0, 12}
     assert phase_tokens == (240, 120)
+    assert len(decided) == 13
 
 
 def test_debris_triage_uses_unified_rubric(temp_dir):
@@ -147,6 +157,28 @@ def test_debris_triage_uses_unified_rubric(temp_dir):
     # V1-5e: the last legacy-prompt holdout flipped onto the unified three-gap
     # rubric, gated by the same-claims A/B in ab-v15e-report.md.
     assert provider.last_system == TRIAGE_SYSTEM_PROMPT
+
+
+def test_decided_findings_carry_suggested_fix_and_severity(temp_dir):
+    """The decided Finding map threads suggested_fix/severity — the product
+    boundary overlay (run_audit_async) reads these to grade Phase 3 issues."""
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    raw = [_debris("dead_code", "`old_helper` is defined but never used", severity="warning")]
+    provider = FakeProvider(_verdicts_result([
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.95,
+         "reasoning": "confirmed dead", "suggested_fix": "delete `old_helper`",
+         "severity": "info"},
+    ]))
+
+    suppressed, _phase_tokens, decided = _run(config, raw, provider)
+
+    assert suppressed == set()
+    finding = decided[0]
+    assert finding.suggested_fix == "delete `old_helper`"
+    assert finding.severity == "info"  # demote-not-drop: Triage may re-grade
+    assert finding.confidence == 0.95
+    assert finding.triage_reasoning == "confirmed dead"
+    assert finding.id
 
 
 def test_provider_failure_records_debris_triage_degradation(temp_dir):
@@ -165,10 +197,11 @@ def test_provider_failure_records_debris_triage_degradation(temp_dir):
     with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
          patch("osoji.symbols.load_all_symbols", return_value={}), \
          patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
-        suppressed, phase_tokens = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
+        suppressed, phase_tokens, decided = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
 
     assert suppressed == set()  # best-effort: nothing suppressed, all kept
     assert phase_tokens == (0, 0)
+    assert decided == {}  # no decided Findings on the failure path
     assert config.audit_degradations == [{"phase": "debris-triage", "error": "boom"}]
 
 
@@ -184,8 +217,95 @@ def test_provider_failure_without_attached_degradations_list_does_not_crash(temp
     with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
          patch("osoji.symbols.load_all_symbols", return_value={}), \
          patch("osoji.audit.create_runtime", side_effect=RuntimeError("boom")):
-        suppressed, phase_tokens = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
+        suppressed, phase_tokens, decided = asyncio.run(_run_phase3_async(config, raw, MagicMock(), False))
 
     assert suppressed == set()  # best-effort: nothing suppressed, all kept
     assert phase_tokens == (0, 0)
+    assert decided == {}
     assert not hasattr(config, "audit_degradations")  # getattr default: no crash, nothing created
+
+
+# --- product-boundary overlay (end-to-end via run_audit_async) ----------------
+
+
+def _write(temp_dir: Path, rel: str, text: str) -> None:
+    path = temp_dir / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_findings(temp_dir: Path, rel_path: str, findings: list[dict]) -> None:
+    findings_file = temp_dir / ".osoji" / "findings" / (rel_path + ".findings.json")
+    findings_file.parent.mkdir(parents=True, exist_ok=True)
+    source_path = temp_dir / rel_path
+    findings_file.write_text(json.dumps({
+        "source": rel_path,
+        "source_hash": compute_file_hash(source_path),
+        "impl_hash": compute_impl_hash(),
+        "generated": "2026-01-01T00:00:00Z",
+        "findings": findings,
+    }), encoding="utf-8")
+
+
+def test_overlay_lands_on_kept_issues_end_to_end(temp_dir):
+    """End-to-end (run_audit_async): a confirmed verdict's severity/suggested-fix
+    /verdict/confidence/triage-reasoning land on the kept AuditIssue, additively
+    (the heuristic remediation is unchanged); a dismissed verdict still
+    suppresses its finding entirely, exactly as before this migration; and a
+    finding with no decided counterpart at all (ineligible for Triage, never
+    built into a claim) keeps its heuristic severity with every Triage field
+    None — the overlay must not assume every kept finding was decided."""
+    _write(temp_dir, "src/x.py",
+           "def old_helper():\n    pass\n\n\ndef also_dead():\n    pass\n# some old code\n")
+    _write_findings(temp_dir, "src/x.py", [
+        {
+            "category": "dead_code", "line_start": 1, "line_end": 2,
+            "severity": "warning", "description": "`old_helper` is defined but never used",
+        },
+        {
+            "category": "dead_code", "line_start": 5, "line_end": 6,
+            "severity": "warning", "description": "`also_dead` is defined but never used",
+        },
+        {
+            "category": "commented_out_code", "line_start": 8, "line_end": 8,
+            "severity": "warning", "description": "a commented-out code block",
+        },
+    ])
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = FakeProvider(_verdicts_result([
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.92,
+         "reasoning": "no references found", "suggested_fix": "delete `old_helper`",
+         "severity": "info"},
+        {"batch_index": 1, "verdict": "dismissed", "confidence": 0.9,
+         "reasoning": "actually used dynamically"},
+    ]))
+
+    with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, exclude={"shadow", "doc-analysis"},
+        ))
+
+    debris_issues = [i for i in result.issues if i.exclude_key == "debris"]
+    assert len(debris_issues) == 2  # dismissed finding (also_dead) suppressed
+    issue = next(i for i in debris_issues if "old_helper" in i.message)
+    assert issue.verdict == "confirmed"
+    assert issue.confidence == 0.92
+    assert issue.triage_reasoning == "no references found"
+    assert issue.suggested_fix == "delete `old_helper`"
+    assert issue.severity == "info"  # re-graded from the heuristic "warning"
+    assert issue.finding_id
+    # The detector's heuristic remediation text stays put — additive, not replaced.
+    assert issue.remediation == "Review and fix the identified issue"
+
+    # The ineligible finding was never built into a claim, so no decided
+    # Finding exists for it: heuristic severity survives, every Triage field
+    # stays None (not crashed on, not fabricated).
+    untriaged = next(i for i in debris_issues if "commented-out" in i.message)
+    assert untriaged.severity == "warning"
+    assert untriaged.finding_id is None
+    assert untriaged.verdict is None
+    assert untriaged.confidence is None
+    assert untriaged.triage_reasoning is None
+    assert untriaged.suggested_fix is None

--- a/tests/test_audit_incremental.py
+++ b/tests/test_audit_incremental.py
@@ -280,7 +280,7 @@ def test_debris_seam_serves_cache_without_llm(temp_dir):
     with patch("osoji.facts.FactsDB", return_value=_FakeFacts()), \
          patch("osoji.symbols.load_all_symbols", return_value={}), \
          patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
-        suppressed, _tokens = asyncio.run(
+        suppressed, _tokens, _decided = asyncio.run(
             _run_phase3_async(config, raw_debris, MagicMock(), False)
         )
 

--- a/tests/test_audit_obligations_cutover.py
+++ b/tests/test_audit_obligations_cutover.py
@@ -20,7 +20,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from osoji.audit import _run_phase3_5_async
+from osoji.audit import _run_phase3_5_async, run_audit_async
 from osoji.config import Config
 from osoji.llm.types import CompletionResult, ToolCall
 from osoji.triage import TRIAGE_SYSTEM_PROMPT
@@ -184,6 +184,62 @@ def test_confirmed_verdict_kept_with_contract_class(temp_dir):
     assert findings[0].contract_class == "unnamed_obligation"
     assert triaged == 1
     assert other == 0
+
+
+def test_confirmed_verdict_carries_triage_outputs_additively(temp_dir):
+    """The Triage outputs (verdict/confidence/reasoning/suggested_fix/id) ride
+    along additively; the heuristic severity/remediation/confidence are
+    untouched (still governed by the silent-value/loud-name rationale)."""
+    _one_implicit_contract_env(temp_dir)
+    provider = FakeProvider(verdicts=[
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
+         "reasoning": "two sites share a bare literal", "contract_class": "unnamed_obligation",
+         "suggested_fix": "extract a shared constant"},
+    ])
+
+    findings, _tokens, _triaged, _other = _run(temp_dir, provider)
+    f = findings[0]
+
+    assert f.verdict == "confirmed"
+    assert f.triage_confidence == 0.8
+    assert f.triage_reasoning == "two sites share a bare literal"
+    assert f.suggested_fix == "extract a shared constant"
+    assert f.finding_id
+    # heuristic fields are unchanged by the overlay (still whatever the
+    # heuristic StringContractChecker proposed, not re-scaled by Triage)
+    assert f.severity == "info"       # heuristic implicit_contract severity
+    assert f.confidence == 0.5        # heuristic confidence, untouched by 0.8 above
+    assert f.remediation              # heuristic remediation text, untouched
+
+
+def test_triage_outputs_land_on_the_audit_issue_end_to_end(temp_dir):
+    """End-to-end (run_audit_async): the ContractFinding's Triage outputs reach
+    the product-boundary AuditIssue, while severity/remediation stay heuristic."""
+    _one_implicit_contract_env(temp_dir)
+    provider = FakeProvider(verdicts=[
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
+         "reasoning": "two sites share a bare literal", "contract_class": "unnamed_obligation",
+         "suggested_fix": "extract a shared constant"},
+    ])
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, obligations=True,
+            exclude={"shadow", "doc-analysis", "debris"},
+        ))
+
+    obligation_issues = [i for i in result.issues if i.exclude_key == "obligations"]
+    assert len(obligation_issues) == 1
+    issue = obligation_issues[0]
+    assert issue.verdict == "confirmed"
+    assert issue.confidence == 0.8
+    assert issue.triage_reasoning == "two sites share a bare literal"
+    assert issue.suggested_fix == "extract a shared constant"
+    assert issue.contract_class == "unnamed_obligation"
+    assert issue.finding_id
+    # severity/remediation stay heuristic — Triage does not re-grade obligations.
+    assert issue.severity == "info"
 
 
 def test_other_class_counts_toward_ce_gap(temp_dir):

--- a/tests/test_deadparam.py
+++ b/tests/test_deadparam.py
@@ -473,6 +473,9 @@ class TestAnalyzerClass:
         assert result.findings[0].metadata["function_name"] == "func"
         # gated_lines died with the per-detector verify tool
         assert result.findings[0].metadata["gated_lines"] == []
+        # Triage outputs: threaded onto JunkFinding additively.
+        assert result.findings[0].finding_id == confirmed.id
+        assert result.findings[0].verdict == "confirmed"
         assert result.total_candidates == 2
         assert result.analyzer_name == "dead_params"
 

--- a/tests/test_doc_analysis_cutover.py
+++ b/tests/test_doc_analysis_cutover.py
@@ -137,6 +137,25 @@ async def test_confirmed_findings_ship(temp_dir):
 
 
 @pytest.mark.asyncio
+async def test_confirmed_finding_carries_suggested_fix_and_finding_id(temp_dir):
+    """DocFinding.suggested_fix / finding_id flow from the decided Finding —
+    additive alongside verdict/confidence/triage_reasoning, which already did."""
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    result = _result_with(temp_dir, [_doc_finding(description="claim A")])
+    provider = FakeProvider(verdicts_per_call=[[
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.9,
+         "reasoning": "real contradiction", "suggested_fix": "update the README flag name"},
+    ]])
+
+    await _triage_doc_findings(provider, config, [result])
+
+    f = result.findings[0]
+    assert f.verdict == "confirmed"
+    assert f.suggested_fix == "update the README flag name"
+    assert f.finding_id
+
+
+@pytest.mark.asyncio
 async def test_dismissed_suppresses(temp_dir):
     config = Config(root_path=temp_dir, respect_gitignore=False)
     result = _result_with(temp_dir, [_doc_finding()])


### PR DESCRIPTION
## What

Triage computes `verdict`, `confidence`, `triage_reasoning`, `suggested_fix`, and a graded `severity` per finding; until now the product boundary discarded most of that — the report kept only heuristic remediation text, so downstream fixers re-derived what Triage already reasoned out. This PR carries Triage outputs through, additively:

- `AuditIssue` gains optional `finding_id` / `verdict` / `confidence` / `triage_reasoning` / `suggested_fix` (the audit-manifest vocabulary). Heuristic `remediation` is unchanged — triage signal rides alongside.
- Phase 3 (debris): issues now overlay the decided finding's fields; **deliberate behavior change**: the triage-graded severity now reaches Phase 3 issues (`decided.severity or heuristic`) — completing the demote-not-drop rubric change (#124), which graded severity at triage but never propagated it to debris issues. On the degradation path (triage failure) issues keep heuristic values.
- Phase 3.5 (obligations): `_overlay_verdict` extended; new `ContractFinding.triage_confidence` is deliberately separate from the pre-existing heuristic `confidence`, which is load-bearing (sort order in three places, `weight_hint` into the Claim Builder). Severity/remediation stay heuristic per the documented rationale.
- Phase 2 (docs): `DocFinding` gains `suggested_fix`/`finding_id`; per-doc analysis JSON includes them.
- Phase 4 (junk): `JunkFinding` gains `finding_id`/`verdict` (confidence was already triage-sourced in all six analyzers). Note: junk issues' JSON `suggested_fix` duplicates `remediation` verbatim (JunkFinding already folds the triage fix into remediation).
- Report: errors section gains `**Suggested fix (triage)**` with `(verdict, confidence)`; JSON emits the new keys omit-if-None (with an `is not None` guard so confidence 0.0 isn't dropped); HTML escapes and renders the fix line; `load_audit_result` round-trips.

## Verification

Full deterministic suite: 1217 passed, 10 skipped. Cutover tests extended to assert the overlay end-to-end with fake providers; zero-confidence JSON case covered; all `_run_phase3_async` call sites updated for the new signature.

## Stacking

Based on `observable-degradation` (#135) — both touch `_run_phase3_async`. The red `audit` check is the pyasn1 advisory, fixed in #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)