### PR TITLE
derive corpus category from detector suffix (osojicode/work#75)

### DIFF
--- a/src/osoji/corpus_emit.py
+++ b/src/osoji/corpus_emit.py
@@ -28,7 +28,6 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from . import __version__
-from .audit import _CLI_FLAG_TO_PRODUCER, _JUNK_NAME_TO_CLI_FLAG
 from .config import SHADOW_DIR
 
 CORPUS_CASE_SCHEMA = "corpus-case/1"
@@ -229,38 +228,6 @@ def _language_for(path: str, override: str | None) -> str:
     return "unknown"
 
 
-# Producer -> corpus category, derived from audit.py's own registries rather
-# than a hand-maintained duplicate: _CLI_FLAG_TO_PRODUCER maps a CLI flag to
-# the producer prefix Finding.detector carries; _JUNK_NAME_TO_CLI_FLAG maps
-# each JunkAnalyzer's .name (its corpus-category spelling, e.g. "dead_code")
-# to that same flag. Chaining producer -> flag -> name gives the category a
-# human already sees in --exclude / CLI help, with zero drift risk since both
-# tables are read live off audit.py's registries.
-_PRODUCER_TO_CLI_FLAG: dict[str, str] = {v: k for k, v in _CLI_FLAG_TO_PRODUCER.items()}
-_CLI_FLAG_TO_CATEGORY: dict[str, str] = {v: k for k, v in _JUNK_NAME_TO_CLI_FLAG.items()}
-
-# The CLI-flag registry chain above is a UI naming convention (--exclude flag
-# identifiers via JunkAnalyzer.name), not the corpus taxonomy -- it happens to
-# already agree with the corpus README's example categories and the legacy
-# debris:<category> vocabulary for five of six JunkAnalyzers, but
-# DeadPlumbingAnalyzer.name is "dead_plumbing" while the corpus taxonomy (the
-# README's own example list, and the legacy debris:plumbing path handled
-# below) calls this category "plumbing". The registry chain cannot be
-# trusted verbatim as the corpus taxonomy -- override the one confirmed
-# collision explicitly rather than silently emitting the wrong directory name.
-_CATEGORY_OVERRIDES: dict[str, str] = {
-    "dead_plumbing": "plumbing",
-}
-
-# Producers outside the JUNK_ANALYZERS registry: Phase 2 (doc analysis),
-# Phase 3 (debris), and Phase 3.5 (obligations) are not JunkAnalyzer
-# subclasses, so they carry no CLI-flag registry entry.
-_SPECIAL_CATEGORY_PRODUCERS: dict[str, str] = {
-    "obligations": "obligations",
-    "doc": "doc_analysis",
-}
-
-
 def _producer_of(detector: str) -> str:
     """The producer half of a ``"<producer>:<category>"`` detector string."""
 
@@ -271,26 +238,28 @@ def _producer_of(detector: str) -> str:
 def _category_of(detector: str) -> str:
     """The corpus directory category for a finding's ``detector`` string.
 
-    ``debris:<category>`` findings (Phase 3) already carry the legacy debris
-    taxonomy (``dead_code`` / ``dead_params`` / ``plumbing`` / ``latent_bug``)
-    as their detector suffix -- the exact category vocabulary the corpus
-    README illustrates -- so that suffix is used directly. Every other
-    producer routes through the CLI-flag chain above; an unrecognized
-    producer falls back to itself so an unknown/future detector never raises.
+    The corpus taxonomy is fine-grained: the accepted case directories
+    (``dead_symbol/``, ``dead_parameter/``, ``unactuated_config/``,
+    ``obligation_implicit_contract/``, ...) are named after the detector's
+    ``:category`` suffix, so that suffix is the category (osojicode/work#75).
+    The legacy debris vocabulary (``debris:dead_code``, ``debris:plumbing``,
+    ...) round-trips as itself under the same rule.
+
+    One producer needs a spelling fix: live doc findings carry unprefixed
+    suffixes (``doc:stale_content``), but the corpus directories use the
+    canonical scorecard spelling audit.py mints (``f"doc_{finding.category}"``
+    -> ``doc_stale_content``), so ``doc:`` suffixes gain that prefix here.
+
+    A suffix-less detector falls back to the producer itself so an
+    unknown/future detector never raises.
     """
 
     producer, _, suffix = (detector or "").partition(":")
     if not producer:
         return "uncategorized"
-    if producer == "debris":
-        return suffix or "debris"
-    if producer in _SPECIAL_CATEGORY_PRODUCERS:
-        return _SPECIAL_CATEGORY_PRODUCERS[producer]
-    cli_flag = _PRODUCER_TO_CLI_FLAG.get(producer)
-    if cli_flag is not None:
-        category = _CLI_FLAG_TO_CATEGORY.get(cli_flag, producer)
-        return _CATEGORY_OVERRIDES.get(category, category)
-    return producer
+    if producer == "doc" and suffix:
+        return f"doc_{suffix}"
+    return suffix or producer
 
 
 def _validate_slug(slug: str) -> None:

--- a/tests/fixtures/prompt_regression/README.md
+++ b/tests/fixtures/prompt_regression/README.md
@@ -25,10 +25,19 @@ language, any project, replays the same way.
 ## `corpus-case/1` — one case directory
 
 Path: `tests/fixtures/prompt_regression/<category>/case_NNN_<slug>/`, where
-`<category>` is the native detector category (`dead_code`, `dead_params`,
-`plumbing`, `obligations`, ...) and `NNN` numbers from `101` up, unique within
-the whole corpus (not per category) so a case's directory name never collides
-across categories once cases move around.
+`<category>` is the native detector category (`dead_symbol`, `dead_parameter`,
+`unactuated_config`, `obligation_implicit_contract`, `doc_stale_content`, ...)
+and `NNN` numbers from `101` up, unique within the whole corpus (not per
+category) so a case's directory name never collides across categories once
+cases move around.
+
+The category is the `:category` suffix of the finding's
+`<producer>:<category>` detector string, with two wrinkles: `doc:` findings
+carry unprefixed suffixes (`doc:stale_content`), so their category gains the
+canonical `doc_` scorecard prefix (`doc_stale_content`); and `debris:`
+findings keep the legacy debris vocabulary (`dead_code`, `latent_bug`,
+`stale_comment`, ...) as-is, which is why debris-swept cases sit in
+`dead_code/` alongside the dedicated detector's `dead_symbol/`.
 
 A case directory contains:
 

--- a/tests/test_corpus_emit.py
+++ b/tests/test_corpus_emit.py
@@ -139,7 +139,7 @@ def test_emit_case_creates_full_stub_layout(tmp_path):
 
     case_dir = emit_case(repo, confirmed.id, "unused-helper", dest)
 
-    assert case_dir == dest / "dead_code" / "case_unused-helper"
+    assert case_dir == dest / "dead_symbol" / "case_unused-helper"
     assert case_dir.exists()
 
     # source/: the flagged file plus the evidence-referenced file, nothing else.
@@ -159,7 +159,7 @@ def test_emit_case_creates_full_stub_layout(tmp_path):
     case_json = json.loads((case_dir / "case.json").read_text(encoding="utf-8"))
     assert case_json["schema"] == "corpus-case/1"
     assert case_json["slug"] == "unused-helper"
-    assert case_json["category"] == "dead_code"
+    assert case_json["category"] == "dead_symbol"
     assert case_json["detector"] == "deadcode"
     assert case_json["gap_type"] == "reachability"
     assert case_json["language"] == "python"
@@ -265,7 +265,7 @@ def test_emit_case_missing_id_raises_with_near_miss_listing(tmp_path):
     assert confirmed.path in message
     assert confirmed.id in message
     assert uncertain.id in message
-    assert not (dest / "dead_code" / "case_whatever").exists()
+    assert not (dest / "dead_symbol" / "case_whatever").exists()
 
 
 def test_emit_case_uncertain_verdict_requires_expected_verdict_override(tmp_path):
@@ -276,7 +276,7 @@ def test_emit_case_uncertain_verdict_requires_expected_verdict_override(tmp_path
         emit_case(repo, uncertain.id, "uncertain-case", dest)
 
     # nothing partially written
-    assert not (dest / "dead_code" / "case_uncertain-case").exists()
+    assert not (dest / "dead_symbol" / "case_uncertain-case").exists()
 
     case_dir = emit_case(repo, uncertain.id, "uncertain-case", dest, expected_verdict="dismissed")
     expected_json = json.loads((case_dir / "expected.json").read_text(encoding="utf-8"))
@@ -298,7 +298,7 @@ def test_emit_case_include_nonexistent_file_raises(tmp_path):
     with pytest.raises(CorpusEmitError, match="does not exist"):
         emit_case(repo, confirmed.id, "bad-include", dest, include=["does/not/exist.py"])
 
-    assert not (dest / "dead_code" / "case_bad-include").exists()
+    assert not (dest / "dead_symbol" / "case_bad-include").exists()
 
 
 def test_emit_case_duplicate_dir_raises(tmp_path):
@@ -344,7 +344,7 @@ def test_emit_case_file_cap_exceeded_raises(tmp_path):
     assert "--include" not in message
     assert "too many files" in message or "targeted evidence" in message
 
-    assert not (dest / "dead_code" / "case_too-big").exists()
+    assert not (dest / "dead_symbol" / "case_too-big").exists()
 
 
 def test_emit_case_missing_finding_path_file_names_no_such_file(tmp_path):
@@ -363,7 +363,7 @@ def test_emit_case_missing_finding_path_file_names_no_such_file(tmp_path):
     # confirmed's evidence) was already copied under case_dir by the time
     # util.py's absence raised -- leaving a half-written case directory
     # behind. Now validated pre-flight, before case_dir is created at all.
-    assert not (dest / "dead_code" / "case_missing-file").exists()
+    assert not (dest / "dead_symbol" / "case_missing-file").exists()
 
 
 def test_emit_case_finding_path_escaping_repo_names_outside_repo(tmp_path):
@@ -380,7 +380,7 @@ def test_emit_case_finding_path_escaping_repo_names_outside_repo(tmp_path):
         emit_case(repo, confirmed.id, "escaping-path", dest)
 
     assert "no such file" not in str(excinfo.value)
-    assert not (dest / "dead_code" / "case_escaping-path").exists()
+    assert not (dest / "dead_symbol" / "case_escaping-path").exists()
 
 
 def test_emit_case_mid_copy_failure_removes_partial_case_dir(tmp_path, monkeypatch):
@@ -409,39 +409,44 @@ def test_emit_case_mid_copy_failure_removes_partial_case_dir(tmp_path, monkeypat
     with pytest.raises(OSError, match="simulated mid-copy failure"):
         emit_case(repo, confirmed.id, "mid-copy-fail", dest)
 
-    assert not (dest / "dead_code" / "case_mid-copy-fail").exists()
+    assert not (dest / "dead_symbol" / "case_mid-copy-fail").exists()
 
 
 # ---------------------------------------------------------------------------
-# category derivation (task-6 review: plumbing/dead_plumbing collision)
+# category derivation (osojicode/work#75: suffix-derived, matches the
+# accepted corpus directories)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     ("detector", "expected_category"),
     [
-        # JunkAnalyzer-backed producers (findings_adapter.py's _JUNK_PRODUCER
-        # + each analyzer's own .name / .cli_flag).
-        ("deadcode:dead_symbol", "dead_code"),
-        ("deadparam:dead_parameter", "dead_params"),
-        # The collision the reviewer caught: DeadPlumbingAnalyzer.name is
-        # "dead_plumbing", but the corpus taxonomy (README example list) and
-        # the legacy debris:plumbing path both call this category "plumbing".
-        ("plumbing:unactuated_config", "plumbing"),
-        ("orphan:orphaned_file", "orphaned_files"),
-        ("deps:dead_dependency", "dead_deps"),
+        # JunkAnalyzer-backed producers (findings_adapter.py's detector
+        # literals): the category is the detector's ``:category`` suffix,
+        # which is exactly how the accepted corpus directories are named
+        # (dead_symbol/, dead_parameter/, unactuated_config/, ...).
+        ("deadcode:dead_symbol", "dead_symbol"),
+        ("deadparam:dead_parameter", "dead_parameter"),
+        ("plumbing:unactuated_config", "unactuated_config"),
+        ("orphan:orphaned_file", "orphaned_file"),
+        ("deps:dead_dependency", "dead_dependency"),
         ("cicd:dead_cicd", "dead_cicd"),
-        # Non-JunkAnalyzer producers (findings_adapter.py: obligations.py's
-        # finding_type, doc_analysis.py's DocFinding.category).
-        ("obligations:obligation_violation", "obligations"),
-        ("obligations:obligation_implicit_contract", "obligations"),
-        ("doc:stale_content", "doc_analysis"),
-        ("doc:misleading_claim", "doc_analysis"),
+        # obligations: suffixes arrive already obligation_-prefixed
+        # (findings_adapter.py prepends it), matching the corpus dirs.
+        ("obligations:obligation_violation", "obligation_violation"),
+        ("obligations:obligation_implicit_contract", "obligation_implicit_contract"),
+        # doc: suffixes arrive UNprefixed (DocFinding.category), but the
+        # corpus dirs and the scorecard spelling (audit.py's
+        # ``f"doc_{finding.category}"``) carry the doc_ prefix.
+        ("doc:stale_content", "doc_stale_content"),
+        ("doc:misleading_claim", "doc_misleading_claim"),
         # debris:<category> (findings_adapter.py's finding_from_debris):
         # today's live tools.py schema enum, plus the corpus README's
         # "legacy bespoke case dirs" names (dead_params, plumbing) that
-        # predate that schema -- both must round-trip as themselves, which
-        # is exactly what would have caught the plumbing collision above.
+        # predate that schema -- the legacy debris vocabulary round-trips
+        # as itself, which is how the accepted corpus stores debris cases
+        # (dead_code/, latent_bug/) alongside the fine-grained detector
+        # dirs (dead_symbol/, unactuated_config/).
         ("debris:dead_code", "dead_code"),
         ("debris:latent_bug", "latent_bug"),
         ("debris:stale_comment", "stale_comment"),
@@ -452,16 +457,8 @@ def test_emit_case_mid_copy_failure_removes_partial_case_dir(tmp_path, monkeypat
         ("debris:plumbing", "plumbing"),
     ],
 )
-def test_category_of_matches_corpus_taxonomy(detector, expected_category):
+def test_category_of_derives_category_from_detector_suffix(detector, expected_category):
     assert _category_of(detector) == expected_category
-
-
-def test_category_of_plumbing_producer_agrees_with_debris_producer():
-    # The two producers that can both describe an unactuated-config /
-    # plumbing-style gap must agree on the corpus directory they file into --
-    # this is the exact invariant the reviewer's plumbing/dead_plumbing
-    # collision violated.
-    assert _category_of("plumbing:unactuated_config") == _category_of("debris:plumbing")
 
 
 # ---------------------------------------------------------------------------
@@ -514,14 +511,14 @@ def test_emitted_case_loads_and_stages_after_acceptance(tmp_path):
     expected["accepted"] = True
     expected_path.write_text(json.dumps(expected), encoding="utf-8")
 
-    accepted_dir = corpus_root / "dead_code" / "case_101_accepted-case"
+    accepted_dir = corpus_root / "dead_symbol" / "case_101_accepted-case"
     accepted_dir.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(case_dir), str(accepted_dir))
 
     cases = load_corpus(corpus_root)
     assert len(cases) == 1
     case = cases[0]
-    assert case.key == "dead_code/case_101_accepted-case"
+    assert case.key == "dead_symbol/case_101_accepted-case"
     assert case.finding.symbol == "unused_helper"
     assert case.expected_verdict == "confirmed"
 
@@ -592,4 +589,4 @@ def test_cli_corpus_emit_creates_case_and_prints_reminder(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert "git mv" in result.output
-    assert (dest / "dead_code" / "case_cli-case" / "case.json").exists()
+    assert (dest / "dead_symbol" / "case_cli-case" / "case.json").exists()


### PR DESCRIPTION
Closes nothing here — tracked as osojicode/work#75 (final-review Important, 2026-07-21 session; gates all future sweeps).

## Problem

`corpus_emit._category_of` collapsed live detectors to **producer-level** categories (`dead_code`, `dead_params`, `plumbing`, `obligations`, `doc_analysis`) via a CLI-flag registry chain, while the accepted 52-case corpus (#144/#145) uses **fine-grained** directories named after the detector's `:category` suffix (`dead_symbol`, `dead_parameter`, `unactuated_config`, `obligation_implicit_contract`, `doc_stale_content`). Left unfixed, the next `osoji corpus emit` files a `dead_symbol` stub into `_holding/dead_code/` next to the accepted `dead_symbol/` cases, `n_cases_by_category` splits one detector across two names, and `test_category_of_matches_corpus_taxonomy` passes while asserting the wrong side.

## Fix (suffix-derivation, the side the reviewer leaned)

- `_category_of` now returns the detector's `:category` suffix — the rule the `debris:` branch already followed and the accepted corpus data embodies. One special case: `doc:` suffixes arrive unprefixed (`doc:stale_content`) and gain the canonical `doc_` scorecard prefix that `audit.py` mints (`f"doc_{finding.category}"`), matching the `doc_stale_content/` dirs. Suffix-less detectors still fall back to the producer (never raises).
- Deleted the now-dead CLI-flag registry chain (`_PRODUCER_TO_CLI_FLAG`, `_CLI_FLAG_TO_CATEGORY`, `_CATEGORY_OVERRIDES`, `_SPECIAL_CATEGORY_PRODUCERS`) and the `audit.py` import feeding it.
- Renamed the parametrized test to `test_category_of_derives_category_from_detector_suffix` with corpus-side expected values; dropped `test_category_of_plumbing_producer_agrees_with_debris_producer` — fine-grained categories intentionally file `plumbing:unactuated_config` (`unactuated_config/`) and `debris:plumbing` (`plumbing/`) into different dirs, exactly as the accepted corpus stores them.
- Corpus README example list updated to the fine-grained vocabulary, documenting the `doc_` prefix and the legacy debris vocabulary.

Accepted corpus dirs, `splits.json`, eval_lib (category is directory-derived), and the sweep skill (already fine-grained) are untouched.

## Verification

- `pytest tests/test_corpus_emit.py` — 42 passed (tests flipped first, confirmed red against old code)
- `pytest tests/test_corpus_structure.py tests/test_eval_lib.py tests/test_corpus_replay.py tests/test_prompt_regression.py` — 113 passed, 1 skipped
- Full `pytest` — 1374 passed, 14 skipped
- Sanity replay: `_category_of` over all live detector literals reproduces the accepted-corpus dir names exactly; residuals are the debris/legacy vocabulary (reachable via `debris:` passthrough) and the three not-yet-swept producers (`orphaned_file`, `dead_dependency`, `dead_cicd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)