### PR TITLE
pin evaluate-baseline.json from the first evaluated corpus run (osojicode/work#35)

### DIFF
--- a/tests/fixtures/prompt_regression/evaluate-baseline.json
+++ b/tests/fixtures/prompt_regression/evaluate-baseline.json
@@ -1,0 +1,23 @@
+{
+  "accuracy_nongray": {
+    "min": 0.62
+  },
+  "tp_rate": {
+    "min": 0.6
+  },
+  "fp_rate": {
+    "max": 0.2
+  },
+  "undecided_rate": {
+    "max": 0.05
+  },
+  "ce_gap_gap_type": {
+    "max": 0.45
+  },
+  "ce_gap_contract_other": {
+    "max": 0.1
+  },
+  "me_overlap": {
+    "max": 0.05
+  }
+}


### PR DESCRIPTION
First measured baseline over the 68-case corpus (60 non-gray) at
main@a74bcbe, run eval-baseline-20260722, canonical TRIAGE_SYSTEM_PROMPT
on the 4.6-tier models:

  accuracy_nongray 0.7167 | tp_rate 0.6970 | fp_rate 0.1111
  uncertain_rate 0.1029 | undecided_rate 0 | escalation_rate 0
  ce_gap_gap_type 0.4265 | ce_gap_contract_other 0 | me_overlap 0

Bounds are measured value +/- ~1.5 sigma single-run binomial noise
(60-case denominator, sd ~5.8pp) -- a smoke gate against regressions,
not the A/B instrument (proctor owns repeats/stats, decisions/0019).
Tighten once repeat variance is measured under work#63.

ce_gap_gap_type at 42.65% is the headline taxonomy-adequacy signal:
the gap_type outlet is absorbing nearly half the corpus, exactly the
falsifiability pressure the epistemological note calls for. Documented
in the wiki falsifiability-metrics page.

Enforced by tests/test_prompt_regression.py --evaluate and the static
subset in tests/test_corpus_structure.py (both tolerant of the file's
absence until now, binding from this commit).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
