### PR TITLE
bind verdicts to reasoning and require concrete failure paths for latent bugs (osojicode/work#78, osojicode/work#79)

### DIFF
--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -461,9 +461,27 @@ class Triage:
         def check_completeness(tool_name: str, tool_input: dict) -> list[str]:
             if tool_name != "submit_triage_verdicts":
                 return []
-            by_index = {
-                v.get("batch_index"): v for v in tool_input.get("verdicts", [])
-            }
+            verdicts = tool_input.get("verdicts", [])
+            # Models occasionally emit the array JSON-encoded as one string,
+            # or entries as bare strings (observed in live corpus replays);
+            # malformed shape must re-ask, never raise.
+            if not isinstance(verdicts, list):
+                return [
+                    "'verdicts' must be a JSON array of verdict objects "
+                    f"(got {type(verdicts).__name__}); resubmit as structured objects"
+                ]
+            malformed = [
+                f"index {j} is a {type(v).__name__}"
+                for j, v in enumerate(verdicts)
+                if not isinstance(v, dict)
+            ]
+            if malformed:
+                return [
+                    "non-object entries in 'verdicts' ("
+                    + "; ".join(malformed)
+                    + "); every entry must be a verdict object"
+                ]
+            by_index = {v.get("batch_index"): v for v in verdicts}
             errors = [
                 f"Missing verdict for batch_index {i}" for i in range(n) if i not in by_index
             ]
@@ -502,7 +520,13 @@ class Triage:
         verdict_by_index: dict[int, dict] = {}
         for tc in result.tool_calls:
             if tc.name == "submit_triage_verdicts":
-                for v in tc.input.get("verdicts", []):
+                raw = tc.input.get("verdicts", [])
+                # Defense in depth behind the validator: a provider without
+                # validator support can still hand back malformed entries;
+                # skip them (undecided) rather than crash the whole batch.
+                for v in raw if isinstance(raw, list) else []:
+                    if not isinstance(v, dict):
+                        continue
                     bi = v.get("batch_index")
                     if bi is not None:
                         verdict_by_index[bi] = v

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -36,6 +36,7 @@ findings that collide on ``id`` cannot reuse a stale verdict.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Collection
 from dataclasses import dataclass, field, replace
 from typing import Any
@@ -83,7 +84,10 @@ A finding is a TRUE POSITIVE iff both predicates hold:
   currently behaves correctly describes a gap that does not exist yet.
 - Actionability — there is a concrete fix.
 Confirm when both hold. Dismiss when either fails. Use 'uncertain' when the
-assembled evidence genuinely cannot decide.
+assembled evidence genuinely cannot decide. A 'confirmed' verdict asserts
+exactly one thing: the finding's claim about the code is true — if your
+reasoning concludes the claim fails, the matching verdict is 'dismissed',
+never 'confirmed'.
 
 """,
     "significance": """\
@@ -210,6 +214,19 @@ sends and a value it receives back are governed alike by the external contract, 
 project obligation. Judge such strings by the protocol that defines them, and apply that
 judgement consistently across the protocol's whole vocabulary — do not confirm one member
 of an external message/status/finish-reason vocabulary while dismissing its siblings.
+
+""",
+    "latent_bug": """\
+A latent-bug claim asserts the code can currently misbehave. Confirm one only
+when you can state the concrete trigger — the specific input, state, or call
+sequence that reaches the failure, and the wrong outcome it produces. If no
+such path can be stated from the assembled evidence — the failure sits behind
+a guard that already handles it, or requires a state the program cannot
+reach — the gap is not real NOW: dismiss on Reality, or use 'uncertain' when
+the evidence genuinely cannot decide. A deliberately pinned value asserted in
+a test-role file (a snapshot pin, a golden value, a self-test expectation) is
+a guard doing its job, not a magic-number bug: read it as declared intent for
+the pinned value, scoped to files whose role is verification.
 
 """,
     "prose_doc_gaps": """\
@@ -610,14 +627,66 @@ class Triage:
 # -- module helpers --------------------------------------------------------
 
 
-def _apply_verdict(finding: Finding, v: dict) -> Finding:
-    """Return a copy of ``finding`` with triage outputs from a verdict dict."""
+_DISMISSAL_WORD = re.compile(r"\bdismiss\w*\b", re.IGNORECASE)
+_CONFIRM_WORD = re.compile(r"\bconfirm\w*\b", re.IGNORECASE)
+_NEGATION_WORD = re.compile(
+    r"\b(?:not|no|none|nothing|never|nor|cannot|can't|don't|doesn't|won't"
+    r"|wouldn't|without|than|instead|rather|avoid\w*|refus\w*)\b",
+    re.IGNORECASE,
+)
 
+
+def _reasoning_contradicts_verdict(verdict: str | None, reasoning: str | None) -> bool:
+    """True when the reasoning's closing statement asserts the opposite verdict.
+
+    The observed failure mode (work#78) is a reasoning that ends "Dismissing on
+    Reality" shipped under ``verdict=confirmed``. Only the final sentence is
+    examined — that is where the rubric's verdict statement lands — and a
+    negation before the verdict word ("nothing justifies dismissing") means the
+    sentence rejects that verdict rather than stating it. High precision over
+    recall: the guard must never demote a verdict whose reasoning merely
+    discusses the opposite outcome.
+    """
+
+    if verdict == "confirmed":
+        opposite = _DISMISSAL_WORD
+    elif verdict == "dismissed":
+        opposite = _CONFIRM_WORD
+    else:
+        return False
+    if not reasoning:
+        return False
+    sentences = [s for s in re.split(r"(?<=[.!?])\s+|\n+", reasoning.strip()) if s.strip()]
+    if not sentences:
+        return False
+    last = sentences[-1]
+    m = opposite.search(last)
+    if not m:
+        return False
+    return not _NEGATION_WORD.search(last[: m.start()])
+
+
+def _apply_verdict(finding: Finding, v: dict) -> Finding:
+    """Return a copy of ``finding`` with triage outputs from a verdict dict.
+
+    Routes verdict/reasoning contradictions to ``uncertain`` (work#78) — a
+    review flag, never a suppression. ``_apply_cached`` replays entries that
+    already passed this guard when first decided, so it stays unguarded.
+    """
+
+    verdict = v.get("verdict")
+    reasoning = v.get("reasoning")
+    if _reasoning_contradicts_verdict(verdict, reasoning):
+        verdict = "uncertain"
+        reasoning = (
+            f"{reasoning} [triage-guard: reasoning contradicts the submitted "
+            f"'{v.get('verdict')}' verdict; routed to uncertain for review]"
+        )
     return replace(
         finding,
-        verdict=v.get("verdict"),
+        verdict=verdict,
         confidence=v.get("confidence"),
-        triage_reasoning=v.get("reasoning"),
+        triage_reasoning=reasoning,
         suggested_fix=v.get("suggested_fix"),
         severity=v.get("severity"),
         contract_class=v.get("contract_class"),

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -13,7 +13,13 @@ from osoji.config import Config
 from osoji.evidence import Evidence
 from osoji.findings import Finding
 from osoji.llm.types import CompletionResult, ToolCall
-from osoji.triage import Claim, Triage, TriageBatchResult, _render_evidence
+from osoji.triage import (
+    Claim,
+    Triage,
+    TriageBatchResult,
+    _apply_verdict,
+    _render_evidence,
+)
 
 
 # --- helpers ---------------------------------------------------------------
@@ -484,3 +490,94 @@ async def test_decide_batch_without_ledger_attached_does_not_crash(config):
     result = await triage.decide_batch(claims, mode="claim")
 
     assert result.findings[0].verdict == "confirmed"
+
+
+# --- verdict/reasoning consistency guard (work#78) -------------------------
+
+
+def test_confirmed_with_trailing_dismissal_reasoning_routes_to_uncertain():
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.85,
+        "reasoning": "The symbol has no live references. Dismissing on Reality.",
+    })
+    assert f.verdict == "uncertain"
+    assert "Dismissing on Reality." in f.triage_reasoning
+    assert "triage-guard" in f.triage_reasoning
+
+
+def test_dismissed_with_trailing_confirm_reasoning_routes_to_uncertain():
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "dismissed",
+        "confidence": 0.8,
+        "reasoning": "Both predicates hold. Confirming on Reality and Actionability.",
+    })
+    assert f.verdict == "uncertain"
+    assert "triage-guard" in f.triage_reasoning
+
+
+def test_confirmed_with_negated_dismissal_language_is_untouched():
+    reasoning = (
+        "The cross-file hits are comments only; nothing justifies dismissing. "
+        "Confirming on both predicates."
+    )
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.9,
+        "reasoning": reasoning,
+    })
+    assert f.verdict == "confirmed"
+    assert f.triage_reasoning == reasoning
+
+
+def test_single_sentence_negated_dismissal_is_untouched():
+    reasoning = "The evidence gives no ground for dismissing this gap."
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.75,
+        "reasoning": reasoning,
+    })
+    assert f.verdict == "confirmed"
+    assert f.triage_reasoning == reasoning
+
+
+def test_matching_verdict_and_reasoning_unchanged():
+    confirmed = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.9,
+        "reasoning": "No live path reaches the symbol. Confirming on both predicates.",
+    })
+    assert confirmed.verdict == "confirmed"
+    dismissed = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "dismissed",
+        "confidence": 0.9,
+        "reasoning": "The import at src/y.py:3 is a real use. Dismissing on Reality.",
+    })
+    assert dismissed.verdict == "dismissed"
+
+
+def test_missing_reasoning_leaves_verdict_unchanged():
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.9,
+    })
+    assert f.verdict == "confirmed"
+    assert f.triage_reasoning is None
+
+
+def test_uncertain_verdict_never_rewritten():
+    f = _apply_verdict(make_finding(), {
+        "batch_index": 0,
+        "verdict": "uncertain",
+        "confidence": 0.4,
+        "reasoning": "Dismissing feels wrong but confirming lacks a path.",
+    })
+    assert f.verdict == "uncertain"
+    assert "triage-guard" not in f.triage_reasoning

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -581,3 +581,48 @@ def test_uncertain_verdict_never_rewritten():
     })
     assert f.verdict == "uncertain"
     assert "triage-guard" not in f.triage_reasoning
+
+
+# --- malformed verdict shapes (observed in live replays) --------------------
+
+
+@pytest.mark.asyncio
+async def test_completeness_validator_rejects_malformed_verdict_shapes(config):
+    # Live corpus replays observed models emitting the verdicts array
+    # JSON-encoded as one string, or entries as bare strings; the validator
+    # crashed (AttributeError) and the whole chunk's claims went undecided.
+    # Malformed shape must be a validation error (re-ask), never an exception.
+    claims = [Claim(make_finding(symbol="a"))]
+    provider = FakeProvider([
+        verdicts_result([{"batch_index": 0, "verdict": "confirmed", "confidence": 0.9, "reasoning": "x"}])
+    ])
+    triage = Triage(config, provider=provider)
+    await triage.decide_batch(claims, mode="claim")
+    validator = provider.calls[0]["options"].tool_input_validators[0]
+
+    as_string = validator("submit_triage_verdicts", {"verdicts": '[{"batch_index": 0}]'})
+    assert as_string and all(isinstance(e, str) for e in as_string)
+
+    entry_string = validator("submit_triage_verdicts", {"verdicts": ["confirmed"]})
+    assert entry_string and all(isinstance(e, str) for e in entry_string)
+
+    non_list = validator("submit_triage_verdicts", {"verdicts": 42})
+    assert non_list and all(isinstance(e, str) for e in non_list)
+
+
+@pytest.mark.asyncio
+async def test_malformed_verdict_entries_do_not_crash_the_batch(config):
+    # Defense in depth for the parse loop: if a malformed entry survives
+    # validation (provider without validator support), the batch must still
+    # decide the well-formed entries and leave the malformed one undecided.
+    claims = [Claim(make_finding(symbol="a")), Claim(make_finding(symbol="b"))]
+    provider = FakeProvider([
+        verdicts_result([
+            "confirmed",
+            {"batch_index": 1, "verdict": "dismissed", "confidence": 0.8, "reasoning": "used via dispatch"},
+        ])
+    ])
+    triage = Triage(config, provider=provider)
+    result = await triage.decide_batch(claims, mode="claim")
+    assert result.findings[0].verdict is None
+    assert result.findings[1].verdict == "dismissed"

--- a/tests/test_triage_sectioning.py
+++ b/tests/test_triage_sectioning.py
@@ -16,10 +16,11 @@ from osoji.triage import (
     render_triage_prompt,
 )
 
-# sha256 of TRIAGE_SYSTEM_PROMPT at the work#66 sectioning refactor. A
-# deliberate rubric change must update this hash in the same PR and carry its
-# A/B evidence (wiki decisions/0022).
-FROZEN_SHA = "16b45f611fc84fb76d60d8bc9ec0ce0c0f65af93c8d2d137014554a4354ed4da"
+# sha256 of TRIAGE_SYSTEM_PROMPT. A deliberate rubric change must update this
+# hash in the same PR and carry its A/B evidence (wiki decisions/0022).
+# History: 16b45f61… at the work#66 sectioning refactor; current hash is the
+# work#78/work#79 change (confirmed-verdict semantics + latent_bug rigor).
+FROZEN_SHA = "67141f5531e49c51a33aba677b1b2966971935ca26d1165f0b6ffff7da9847e9"
 
 
 def test_assembled_prompt_is_byte_identical() -> None:
@@ -32,7 +33,7 @@ def test_full_render_matches_constant() -> None:
 
 
 def test_sections_are_nonempty() -> None:
-    assert len(TRIAGE_PROMPT_SECTIONS) == 15
+    assert len(TRIAGE_PROMPT_SECTIONS) == 16
     for name, text in TRIAGE_PROMPT_SECTIONS.items():
         assert text, f"empty section: {name}"
 


### PR DESCRIPTION
## Mechanism

Two sweep-observed triage failure classes:
- **osojicode/work#78**: findings shipped `verdict=confirmed` while their own reasoning ended "Dismissing on Reality" — verdict and reasoning are copied from independent tool-output fields with no cross-check.
- **osojicode/work#79**: three latent-bug confirms (0.75–0.88 confidence) were mechanically refutable; the rubric had no latent-bug guidance at all (only a one-line mention in the mission section).

A third failure surfaced while measuring this change: live replays crashed whole 6-claim chunks with `'str' object has no attribute 'get'` when the model emitted malformed verdict entries (the same chunk failed in 3 of 4 A/B passes, in **both** arms — pre-existing, not rubric-induced).

## Changes

1. **Post-decide consistency guard** (code): when the reasoning's closing sentence asserts the opposite verdict (negation-aware, final-sentence-only for precision), the verdict routes to `uncertain` with an explicit `[triage-guard: …]` marker — review flag, never suppression. Cached verdicts replay entries that already passed the guard.
2. **Rubric, `predicates` section**: one sentence pinning `confirmed` = the finding's claim about the code is true.
3. **Rubric, new `latent_bug` section**: confirming requires a stateable concrete input/state→failure path; guarded/unreachable failures fail Reality. Deliberately pinned values in test-role files are guards, not magic-number bugs. Principle-level, language-agnostic; the section is automatically a leave-one-out ablation target.
4. **Verdict shape validation**: malformed `verdicts` payloads (stringified array, non-object entries) now produce a validation error → provider re-asks; the parse loop also skips non-dict entries defensively. Sectioning sha pin updated per policy.

## Evidence (wiki decisions/0022)

A/B `ab-work78-79-20260722` (old vs new rubric, 2 repeats × 68 cases, local NDJSON per ablation-methodology): fp_rate 0.154→0.120, accuracy 0.822→0.827, tp_rate 0.781→0.758. Case-level majority flips: one FP fixed outright, one uncertain→correct dismissal, one FP softened to uncertain; costs are one TP→uncertain via the new guard firing as designed, and one TP flip on a case whose snapshot was polluted pre-#152.

Canonical gate `eval-20260722-dea84d5e` (new rubric, repaired corpus, 1 pass): **all pinned thresholds hold** — tp 0.667 (min 0.6), fp 0.111 (max 0.2, = baseline), accuracy_nongray 0.700 (min 0.62), undecided 0.0 (the malformed-entry re-ask removed all null-verdict chunks), uncertain 0.103 (= baseline).

## Tests

TDD throughout: 9 new unit tests (guard behavior incl. negation cases; malformed-shape validation and parse-loop resilience). Full suite: 1387 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)