### PR TITLE
correct migration-mislabeled gap_type in 14 corpus cases (osojicode/work#35)

### DIFF
--- a/tests/fixtures/prompt_regression/doc_incorrect_content/case_124_audit-doc_incorrect_content-000/case.json
+++ b/tests/fixtures/prompt_regression/doc_incorrect_content/case_124_audit-doc_incorrect_content-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-doc_incorrect_content-000",
   "category": "doc_incorrect_content",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "language": "markdown",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/doc_incorrect_content/case_124_audit-doc_incorrect_content-000/finding.json
+++ b/tests/fixtures/prompt_regression/doc_incorrect_content/case_124_audit-doc_incorrect_content-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:doc_incorrect_content",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "path": ".claude/skills/osoji-triage/SKILL.md",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/doc_incorrect_content/case_125_audit-doc_incorrect_content-001/case.json
+++ b/tests/fixtures/prompt_regression/doc_incorrect_content/case_125_audit-doc_incorrect_content-001/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-doc_incorrect_content-001",
   "category": "doc_incorrect_content",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "language": "markdown",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/doc_incorrect_content/case_125_audit-doc_incorrect_content-001/finding.json
+++ b/tests/fixtures/prompt_regression/doc_incorrect_content/case_125_audit-doc_incorrect_content-001/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:doc_incorrect_content",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "path": "docs/explanatory/facts-database-and-import-graphs.md",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/doc_misleading_claim/case_126_audit-doc_misleading_claim-000/case.json
+++ b/tests/fixtures/prompt_regression/doc_misleading_claim/case_126_audit-doc_misleading_claim-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-doc_misleading_claim-000",
   "category": "doc_misleading_claim",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "language": "markdown",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/doc_misleading_claim/case_126_audit-doc_misleading_claim-000/finding.json
+++ b/tests/fixtures/prompt_regression/doc_misleading_claim/case_126_audit-doc_misleading_claim-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:doc_misleading_claim",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "path": ".claude/skills/osoji-sweep/SKILL.md",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/doc_obsolete_reference/case_127_audit-doc_obsolete_reference-000/case.json
+++ b/tests/fixtures/prompt_regression/doc_obsolete_reference/case_127_audit-doc_obsolete_reference-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-doc_obsolete_reference-000",
   "category": "doc_obsolete_reference",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "language": "markdown",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/doc_obsolete_reference/case_127_audit-doc_obsolete_reference-000/finding.json
+++ b/tests/fixtures/prompt_regression/doc_obsolete_reference/case_127_audit-doc_obsolete_reference-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:doc_obsolete_reference",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "path": "docs/explanatory/llm-tool-schemas-and-validation.md",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/doc_stale_content/case_128_audit-doc_stale_content-000/case.json
+++ b/tests/fixtures/prompt_regression/doc_stale_content/case_128_audit-doc_stale_content-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-doc_stale_content-000",
   "category": "doc_stale_content",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "language": "markdown",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/doc_stale_content/case_128_audit-doc_stale_content-000/finding.json
+++ b/tests/fixtures/prompt_regression/doc_stale_content/case_128_audit-doc_stale_content-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:doc_stale_content",
-  "gap_type": "uncategorized",
+  "gap_type": "description",
   "path": "CLAUDE.md",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-000",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "src/osoji/audit.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-001",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "src/osoji/init.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-002",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "tests/test_claude_code_provider.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-003",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "tests/test_impl_hash.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-004",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "tests/test_junk_orphan.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-005",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "tests/test_llm_provider.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/case.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_implicit_contract-006",
   "category": "obligation_implicit_contract",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_implicit_contract",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "tests/test_plugin_python.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_violation/case_145_audit-obligation_violation-000/case.json
+++ b/tests/fixtures/prompt_regression/obligation_violation/case_145_audit-obligation_violation-000/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_violation-000",
   "category": "obligation_violation",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_violation/case_145_audit-obligation_violation-000/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_violation/case_145_audit-obligation_violation-000/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_violation",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "src/osoji/audit.py",
   "line_start": null,
   "line_end": null,

--- a/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/case.json
+++ b/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/case.json
@@ -3,7 +3,7 @@
   "slug": "audit-obligation_violation-001",
   "category": "obligation_violation",
   "detector": "audit",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "language": "python",
   "origin": {
     "repo": "osoji",

--- a/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/finding.json
+++ b/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/finding.json
@@ -1,6 +1,6 @@
 {
   "detector": "audit:obligation_violation",
-  "gap_type": "uncategorized",
+  "gap_type": "contract",
   "path": "src/osoji/llm/google.py",
   "line_start": null,
   "line_end": null,

--- a/tests/test_corpus_structure.py
+++ b/tests/test_corpus_structure.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(REPO_ROOT / "src"))
 
 import eval_lib  # noqa: E402
 from osoji.findings import Finding  # noqa: E402
+from osoji.findings_adapter import CATEGORY_TO_GAP_TYPE  # noqa: E402
 
 BASELINE_PATH = eval_lib.CORPUS_ROOT / "evaluate-baseline.json"
 
@@ -90,6 +91,59 @@ def test_every_finding_json_round_trips_through_finding_preserving_id():
             assert finding.id == data["id"], (
                 f"{finding_path}: a non-empty stored id must survive from_dict verbatim"
             )
+
+
+# ---------------------------------------------------------------------------
+# gap_type matches CATEGORY_TO_GAP_TYPE (osojicode/work#35)
+# ---------------------------------------------------------------------------
+#
+# The V1-7 bootstrap migration synthesized case.json/finding.json data whose
+# ``detector`` field carries a prefixed ``"<producer>:<category>"`` spelling
+# (e.g. ``audit:obligation_implicit_contract``, ``audit:doc_obsolete_reference``),
+# but stamped ``gap_type`` by looking up the persisted-category-shaped keys
+# ``CATEGORY_TO_GAP_TYPE`` actually contains (unprefixed, no ``doc_`` prefix).
+# That mismatch is exactly what let 14/68 cases land in the corpus tagged
+# ``uncategorized`` instead of their real gap_type. This guard derives the
+# expected gap_type from each finding's detector suffix the same way, so a
+# repeat of that migration bug fails CI instead of quietly recurring.
+
+
+def _expected_gap_type_from_detector(detector: str) -> str:
+    """Candidate category derivation mirroring the corpus-correction script:
+    the raw detector suffix, then that suffix with a leading ``doc_`` stripped."""
+
+    suffix = detector.split(":", 1)[1] if ":" in detector else detector
+    candidates = [suffix]
+    if suffix.startswith("doc_"):
+        candidates.append(suffix[len("doc_") :])
+    for candidate in candidates:
+        if candidate in CATEGORY_TO_GAP_TYPE:
+            return CATEGORY_TO_GAP_TYPE[candidate]
+    return "uncategorized"
+
+
+def test_every_case_gap_type_matches_category_to_gap_type():
+    violations = []
+    for case_json_path in _case_json_paths():
+        case_data = json.loads(case_json_path.read_text(encoding="utf-8"))
+        finding_path = case_json_path.parent / "finding.json"
+        finding_data = json.loads(finding_path.read_text(encoding="utf-8"))
+
+        detector = finding_data.get("detector", "")
+        expected = _expected_gap_type_from_detector(detector)
+
+        if case_data.get("gap_type") != expected:
+            violations.append(
+                f"{case_json_path}: gap_type={case_data.get('gap_type')!r}, "
+                f"expected {expected!r} from detector {detector!r}"
+            )
+        if finding_data.get("gap_type") != expected:
+            violations.append(
+                f"{finding_path}: gap_type={finding_data.get('gap_type')!r}, "
+                f"expected {expected!r} from detector {detector!r}"
+            )
+
+    assert not violations, "\n".join(violations)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Mechanism

\`CATEGORY_TO_GAP_TYPE\` in \`src/osoji/findings_adapter.py\` routes obligation
categories → \`contract\` and doc categories (unprefixed spellings:
\`stale_content\`, \`obsolete_reference\`, …) → \`description\`; \`latent_bug\` is
omitted on purpose → \`uncategorized\`. The V1-7 bootstrap migration, however,
synthesized findings whose \`detector\` field carries prefixed category
spellings (\`audit:obligation_implicit_contract\`, \`audit:doc_obsolete_reference\`,
…), so \`gap_type_for()\` missed the mapping keys and stamped \`uncategorized\`
into the committed corpus data. Result: every obligation case (9) and five
doc cases carried \`gap_type: uncategorized\` in both \`case.json\` and
\`finding.json\`, while the live propose-time paths (\`finding_from_contract\`,
\`finding_from_doc\`) emit \`contract\`/\`description\` today.

**This is not cosmetic.** \`gap_type\` renders into the triage claim header
(\`src/osoji/triage.py:556\`), so it steers which rubric sections engage —
mislabeled cases were feeding Triage a header that doesn't match the
category the live pipeline would actually produce.

## Fix

Ran a one-off script (not committed) against every accepted corpus case
under \`tests/fixtures/prompt_regression/\`: derive the finding's category
candidates from the detector suffix (\`detector.split(':', 1)[1]\`, plus that
suffix with a leading \`doc_\` stripped), look up \`CATEGORY_TO_GAP_TYPE\`
(imported — single source of truth), and rewrite \`gap_type\` in both
\`case.json\` and \`finding.json\` where it disagreed with the derived value,
preserving each file's JSON formatting (indentation, key order, line
endings, trailing newline).

Result matched the expected shape exactly: **9 obligation cases → \`contract\`,
5 doc cases → \`description\`, 14 total**. \`latent_bug\` cases are untouched —
\`uncategorized\` is their correct, deliberate mapping (the adapter can't
mechanically tell a stated-invariant violation from an implicit one).
\`expected.json\`, sidecars, and \`splits.json\` were not touched.

## Test

Added \`test_every_case_gap_type_matches_category_to_gap_type\` to
\`tests/test_corpus_structure.py\` (TDD): for every accepted case, re-derives
the expected \`gap_type\` from \`CATEGORY_TO_GAP_TYPE\` using the same
detector-suffix rule and asserts both \`case.json\` and \`finding.json\` match
it. Verified it fails against the pre-fix tree (28 violations across the 14
cases) and passes after the correction — this is the guard that would have
caught the migration bug.

\`\`\`
PYTHONPATH=src python -m pytest tests/test_corpus_structure.py -v
21 passed

PYTHONPATH=src python -m pytest -m "not prompt_regression and not live_smoke and not corpus_evaluate" -q
1421 passed, 10 skipped, 11 deselected
\`\`\`

## Verdict-affecting — evaluator gate required before merge

This changes corpus data that feeds the triage claim header, so **the
controller will run the evaluator gate on this branch before merge** (not
run here — no API spend from this agent). Corpus-measured static metric
\`ce_gap_gap_type\` should drop from **29/68 (0.4265) to 15/68 (0.2206)** on
the next evaluated run — confirmed locally via \`eval_lib.compute_metrics\`
(deterministic, no LLM calls), which already reports 0.2206 against the
committed \`evaluate-baseline.json\` max threshold of 0.45 (no violation
either before or after).

References \`osojicode/work#35\` and informs the gap-taxonomy review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)