### PR TITLE
fix retry-budget expansion never firing on anthropic truncation (#159)

### DIFF
--- a/src/osoji/doc_analysis.py
+++ b/src/osoji/doc_analysis.py
@@ -418,7 +418,11 @@ async def _analyze_document_async(
         system=_ANALYZE_SYSTEM_PROMPT,
         options=CompletionOptions(
             model=config.model_for("large"),
-            max_tokens=2048,
+            # 2048 truncated mid-tool-call on doc-heavy repos (57 analyze_document
+            # failures, stop_reason=max_tokens, missing `findings`); the retried
+            # resend of the ~100K-token large-tier input is the real cost, so a
+            # bigger first-attempt cap avoids paying for a doomed-to-fail retry.
+            max_tokens=4096,
             max_input_tokens=input_budget_for_config(config),
             reservation_key="doc.analyze",
             tools=get_analyze_document_tool_definitions(),

--- a/src/osoji/llm/_provider_base.py
+++ b/src/osoji/llm/_provider_base.py
@@ -29,6 +29,13 @@ from .validate import validate_tool_input
 _MAX_TOOL_VALIDATION_ATTEMPTS = 3
 _DEFAULT_LLM_TIMEOUT = 600  # seconds; override with OSOJI_LLM_TIMEOUT env var
 
+# Provider stop-reason vocabularies for output-token truncation differ: OpenAI's
+# finish_reason is "length", google.py normalizes Google's MAX_TOKENS to "length",
+# but the anthropic SDK passes its raw stop_reason "max_tokens" straight through
+# (deliberately left unnormalized — other consumers match on the raw value). Both
+# must be recognized here so the retry-budget expansion fires on every provider.
+_TRUNCATION_STOP_REASONS = frozenset({"length", "max_tokens"})
+
 logger = logging.getLogger(__name__)
 
 
@@ -433,7 +440,7 @@ class DirectProvider(LLMProvider):
         base_max_tokens: int,
         stop_reason: str | None,
     ) -> int:
-        if stop_reason != "length":
+        if stop_reason not in _TRUNCATION_STOP_REASONS:
             return current_max_tokens
         if current_max_tokens > base_max_tokens:
             return current_max_tokens

--- a/tests/test_tool_retry.py
+++ b/tests/test_tool_retry.py
@@ -17,7 +17,7 @@ from osoji.llm.types import (
 from osoji.llm.anthropic import AnthropicProvider
 
 
-def _make_response(content_blocks, input_tokens=100, output_tokens=50):
+def _make_response(content_blocks, input_tokens=100, output_tokens=50, stop_reason="tool_use"):
     """Build a fake Anthropic API response."""
     blocks = []
     for b in content_blocks:
@@ -26,7 +26,7 @@ def _make_response(content_blocks, input_tokens=100, output_tokens=50):
         content=blocks,
         usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
         model="claude-test",
-        stop_reason="tool_use",
+        stop_reason=stop_reason,
     )
 
 
@@ -225,6 +225,78 @@ class TestInvalidInputTriggersRetry:
         tool_result_block = retry_messages[2]["content"][0]
         assert tool_result_block["is_error"] is True
         assert "expected object" in tool_result_block["content"]
+
+    def test_retry_expands_max_tokens_on_anthropic_truncation_stop_reason(self, provider):
+        """Anthropic's raw stop_reason is "max_tokens", not the "length" OpenAI/Google
+        use — the retry-budget expansion must still fire so the resend doesn't repeat
+        the identical truncated request into the same cap."""
+        bad_input = {"value": "not-an-object"}
+        first_response = _make_response(
+            [_tool_use_block("tc1", "test_tool", bad_input)],
+            input_tokens=100,
+            output_tokens=50,
+            stop_reason="max_tokens",
+        )
+        good_input = {"value": {"x": "fixed"}}
+        second_response = _make_response(
+            [_tool_use_block("tc2", "test_tool", good_input)],
+            input_tokens=120,
+            output_tokens=60,
+        )
+        provider._client.messages.create = AsyncMock(
+            side_effect=[first_response, second_response]
+        )
+
+        options = CompletionOptions(
+            model="claude-test",
+            max_tokens=128,
+            tools=[TOOL_DEF],
+            tool_choice=FORCED_CHOICE,
+        )
+        messages = [Message(role=MessageRole.USER, content="test")]
+
+        result = asyncio.run(provider.complete(messages, None, options))
+
+        assert provider._client.messages.create.call_count == 2
+        assert provider._client.messages.create.call_args_list[1].kwargs["max_tokens"] == 256
+        assert result.tool_calls[0].input == good_input
+
+
+class TestMaybeExpandMissingToolMaxTokens:
+    """Direct unit tests for the truncation-detection guard.
+
+    Provider stop-reason vocabularies differ: OpenAI's finish_reason is "length",
+    google.py normalizes Google's MAX_TOKENS to "length", but Anthropic's SDK
+    passes its raw stop_reason "max_tokens" straight through. Both must be
+    treated as truncation.
+    """
+
+    @pytest.mark.parametrize("stop_reason", ["length", "max_tokens"])
+    def test_doubles_cap_on_truncation_stop_reasons(self, provider, stop_reason):
+        expanded = provider._maybe_expand_missing_tool_max_tokens(
+            current_max_tokens=128,
+            base_max_tokens=128,
+            stop_reason=stop_reason,
+        )
+        assert expanded == 256
+
+    @pytest.mark.parametrize("stop_reason", ["end_turn", None, "tool_use", "stop"])
+    def test_unchanged_for_non_truncation_stop_reasons(self, provider, stop_reason):
+        expanded = provider._maybe_expand_missing_tool_max_tokens(
+            current_max_tokens=128,
+            base_max_tokens=128,
+            stop_reason=stop_reason,
+        )
+        assert expanded == 128
+
+    def test_never_expands_past_base_times_two(self, provider):
+        # Already expanded in a prior retry attempt -> stays put, doesn't double again.
+        expanded = provider._maybe_expand_missing_tool_max_tokens(
+            current_max_tokens=256,
+            base_max_tokens=128,
+            stop_reason="max_tokens",
+        )
+        assert expanded == 256
 
 
 class TestTokenSumming:


### PR DESCRIPTION
## Mechanism

`osoji audit` on a doc-heavy repo lost 57 doc analyses to "Schema validation failed after 3 attempts for analyze_document: missing required field 'findings'". The raw interaction log showed `stop_reason="max_tokens"`, `output_tokens=2048` (== the request cap): the tool-call JSON truncated before `findings` was emitted, the SDK salvaged a partial input dict, and schema validation failed.

The expansion mechanism that exists for exactly this — `_maybe_expand_missing_tool_max_tokens` in `src/osoji/llm/_provider_base.py` — never fired on the anthropic provider, because its guard was `if stop_reason != "length"`. Provider stop-reason vocabularies differ: OpenAI's `finish_reason` is `"length"`, `google.py` normalizes Google's `MAX_TOKENS` to `"length"`, but the anthropic SDK's raw `stop_reason` is `"max_tokens"` and is passed through unnormalized. So every anthropic retry after a truncated tool call resent the *identical* request (~100K input tokens on the large tier, three attempts) into the *same* 2048 cap — deterministic failure, tripled cost, zero benefit.

## Fix

1. `_provider_base.py`: introduced `_TRUNCATION_STOP_REASONS = frozenset({"length", "max_tokens"})` and use it in `_maybe_expand_missing_tool_max_tokens`'s guard, with a comment naming the vocabulary difference. `anthropic.py`'s raw `stop_reason` is left unnormalized (other consumers match on the raw value) — only the guard changed.
2. `doc_analysis.py`: raised `analyze_document`'s `max_tokens` 2048 → 4096, with a comment citing the observed 57-failure truncation class. The retry resend of the large-tier input is the real cost, so the first attempt should now usually fit; the (now-working) expansion mechanism is the backstop if it doesn't. Line 285's classification-only call (`max_tokens=1024`) is untouched — no truncation was observed there.

**Rate limiter note**: `RateLimitedProvider` reserves output-TPM budget via `rate_limiter.acquire(max_output_tokens=options.max_tokens)`. `_select_output_reservation` reserves the *full* `max_output_tokens` while a reservation-key's `conservative_remaining` warm-up counter is > 0 (first 5 calls per key, and it resets whenever actual usage under-runs the reservation) — during those windows the `doc.analyze` key will now reserve 4096 instead of 2048. Once enough samples exist, reservation is tuned from p90/avg of actual usage and capped at `max_output_tokens`, so steady-state reservation only grows if actual output regularly approaches the new cap. Net effect: doubled *reservation* (throttling headroom) for `doc.analyze` during warm-up/reset windows, not doubled *billed* tokens — actual cost only rises if a call now legitimately needs the extra headroom to avoid truncating.

## Tests

- `tests/test_tool_retry.py::TestMaybeExpandMissingToolMaxTokens` — direct unit coverage: doubles the cap for `stop_reason` `"length"` and `"max_tokens"`, leaves it unchanged for `"end_turn"`/`None`/`"tool_use"`/`"stop"`, and never expands past `base * 2` (existing semantics preserved).
- `tests/test_tool_retry.py::TestInvalidInputTriggersRetry::test_retry_expands_max_tokens_on_anthropic_truncation_stop_reason` — behavior test: a first response with schema-invalid tool input and `stop_reason="max_tokens"` causes the retry request's `max_tokens` to double, following the existing fake-SDK mocking pattern in that file.

`PYTHONPATH=src python -m pytest tests/test_tool_retry.py tests/test_llm_provider.py tests/test_doc_analysis_cutover.py tests/test_rate_limiter.py -q` → 78 passed.
Full suite: `PYTHONPATH=src python -m pytest -m "not prompt_regression and not live_smoke and not corpus_evaluate" -q` → 1429 passed, 10 skipped, 11 deselected.

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)