### PR TITLE
honor [audit] exclude globs in repository discovery (osojicode/work#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `[audit] exclude` in `.osoji.toml` — repo-relative glob patterns that
+  remove matching paths from repository discovery entirely, scoping
+  expensive analysis away from low-value trees (e.g. `docs/archive/**`)
+
 ### Changed
 
 - LLM providers migrated from LiteLLM to direct SDKs (`anthropic`, `openai`,

--- a/README.md
+++ b/README.md
@@ -137,6 +137,27 @@ Config precedence (highest to lowest):
 
 Run `osoji config show` to inspect the effective policy.
 
+### Excluding paths from analysis
+
+Scope expensive analysis away from low-value trees (e.g. a doc archive) with
+`[audit] exclude` in `.osoji.toml`:
+
+```toml
+# .osoji.toml (per-project, committed)
+
+[audit]
+exclude = ["docs/archive/**", "vendor/**"]
+```
+
+Patterns are repo-relative [`fnmatch`](https://docs.python.org/3/library/fnmatch.html)
+globs matched against each file's path relative to the project root. `*`
+already matches any run of characters including `/`, so `**` behaves the
+same as `*` — write it for readability. Matched paths are dropped from
+repository discovery entirely: no shadow docs, no facts, no analysis, no
+findings. There's no built-in catalog and no default excludes — this is an
+explicit, per-project scope decision you declare, not a heuristic osoji
+applies on your behalf.
+
 ## Requirements
 
 - Python 3.11+

--- a/docs/explanatory/shadow-documentation-architecture.md
+++ b/docs/explanatory/shadow-documentation-architecture.md
@@ -53,6 +53,11 @@ The main orchestration lives in `generate_shadow_docs_async()` in `src/osoji/sha
 - Uses `git ls-files` when available (respecting `.gitignore`)
 - Falls back to recursive glob when git is unavailable
 - Filters by configured extensions, ignore patterns, and `.osojiignore`
+- Drops paths matching `.osoji.toml`'s `[audit] exclude` globs (repo-relative
+  `fnmatch` patterns, e.g. `docs/archive/**`) in both the `git ls-files` and
+  rglob-fallback paths, alongside the corpus-snapshot exclusion — a
+  project-scoped, user-declared scope decision, not a built-in heuristic
+  (osojicode/work#90)
 - Skips the `.osoji/` directory (Osoji's own output)
 - Skips documentation candidates (identified by extension, filename, or parent directory)
 - Sorts results by depth, deepest first, for bottom-up processing

--- a/src/osoji/config.py
+++ b/src/osoji/config.py
@@ -221,6 +221,28 @@ def _read_optional_str(value: Any, *, context: str) -> str | None:
     return stripped or None
 
 
+def _read_exclude_patterns(value: Any, *, context: str) -> list[str]:
+    """Validate and normalize an `[audit] exclude` glob list.
+
+    Must be a list of strings when present; blank entries are dropped.
+    A missing value (key absent) normalizes to an empty list -- not an
+    error, since absent means "no change".
+    """
+
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RuntimeError(f"{context} must be a list of glob patterns.")
+    patterns: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise RuntimeError(f"{context} entries must be strings.")
+        stripped = item.strip()
+        if stripped:
+            patterns.append(stripped)
+    return patterns
+
+
 def _normalize_provider(value: str, *, context: str) -> str:
     """Normalize and validate a provider name."""
 
@@ -887,6 +909,42 @@ class Config:
                 if normalized:
                     extra_patterns.append(normalized)
         return extra_patterns
+
+    def load_audit_exclude(self) -> list[str]:
+        """Load `[audit] exclude` glob patterns from the committed project
+        config (.osoji.toml).
+
+        Patterns are repo-relative fnmatch globs the walker uses to remove
+        matching paths from repository discovery entirely (see
+        `walker._exclude_configured_globs`). This is a project-scoped,
+        user-declared decision (osojicode/work#90) -- there is no built-in
+        catalog and no default excludes, so an absent file, an absent
+        `[audit]` table, or an absent/empty `exclude` key all mean
+        "no change" (empty list). A malformed shape raises a clear
+        RuntimeError, consistent with the rest of config.py's TOML loading.
+        """
+
+        path = self.root_path / PROJECT_CONFIG_FILENAME
+        if not path.exists():
+            return []
+        try:
+            data = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise RuntimeError(f"Invalid Osoji config file {path}: {exc}") from exc
+        except OSError as exc:
+            raise RuntimeError(f"Failed to read Osoji config file {path}: {exc}") from exc
+
+        if not isinstance(data, dict):
+            raise RuntimeError(f"Osoji config file {path} must contain a TOML table.")
+
+        audit_section = data.get("audit")
+        if audit_section is None:
+            return []
+        if not isinstance(audit_section, dict):
+            raise RuntimeError(f"{path}: [audit] must be a TOML table.")
+
+        return _read_exclude_patterns(audit_section.get("exclude"), context=f"{path}: audit.exclude")
+
     def is_doc_candidate(self, path: Path) -> bool:
         """Check if a path is a documentation file candidate.
 

--- a/src/osoji/walker.py
+++ b/src/osoji/walker.py
@@ -144,13 +144,54 @@ def _exclude_corpus_snapshots(paths: list[Path], root: Path) -> list[Path]:
     return [p for p in paths if not is_under_corpus_snapshot(p, root, cache)]
 
 
+def _matches_exclude_pattern(relative_posix: str, patterns: list[str]) -> bool:
+    """True if a root-relative POSIX path matches any user exclude glob.
+
+    Patterns are matched with ``fnmatch.fnmatch``, which treats ``*`` as
+    matching any run of characters -- including ``/`` -- since it has no
+    concept of a path separator. That means ``**`` behaves identically to a
+    single ``*``; it's accepted for readability and familiarity with
+    shell-glob conventions (e.g. ``docs/archive/**``), not because it adds
+    recursion a lone ``*`` doesn't already have.
+    """
+    return any(fnmatch.fnmatch(relative_posix, pattern) for pattern in patterns)
+
+
+def _exclude_configured_globs(paths: list[Path], root: Path, patterns: list[str]) -> list[Path]:
+    """Drop every path matching a user-configured ``[audit] exclude`` glob.
+
+    Patterns come from ``.osoji.toml``'s ``[audit].exclude``
+    (``Config.load_audit_exclude()``) and are matched against each path's
+    POSIX-style location relative to ``root``. Because matching is always
+    against that in-root relative string, an absolute or ``../``-prefixed
+    pattern can never reach outside ``root`` -- it simply never matches a
+    real path. Language-agnostic by construction: these are user-supplied
+    path patterns, no built-in catalog, no default excludes. Exclusion here
+    is an explicit, user-declared scope decision -- the config IS declared
+    intent -- not a silent heuristic (osojicode/work#90).
+    """
+    if not patterns:
+        return paths
+    kept: list[Path] = []
+    for path in paths:
+        try:
+            relative = path.relative_to(root).as_posix()
+        except ValueError:
+            kept.append(path)
+            continue
+        if not _matches_exclude_pattern(relative, patterns):
+            kept.append(path)
+    return kept
+
+
 def list_repo_files(config: Config) -> tuple[Iterable[Path], bool]:
     """Shared entry point for git-aware file listing.
 
     Returns (paths, used_git) where used_git indicates whether
     git ls-files was used (True) or rglob fallback (False).
     Results are cached per (root_path, respect_gitignore) so git ls-files only runs once.
-    Corpus-case snapshot subtrees are excluded from both discovery paths.
+    Corpus-case snapshot subtrees and paths matching the project's
+    `[audit] exclude` globs are excluded from both discovery paths.
     """
     key = (config.root_path, config.respect_gitignore)
 
@@ -158,16 +199,20 @@ def list_repo_files(config: Config) -> tuple[Iterable[Path], bool]:
         cached_paths, used_git = _repo_files_cache[key]
         return list(cached_paths), used_git
 
+    exclude_patterns = config.load_audit_exclude()
+
     if config.respect_gitignore:
         git_files = _git_ls_files(config.root_path, quiet=config.quiet)
         if git_files is not None:
             git_files = _exclude_corpus_snapshots(git_files, config.root_path)
+            git_files = _exclude_configured_globs(git_files, config.root_path, exclude_patterns)
             _repo_files_cache[key] = (git_files, True)
             return list(git_files), True
 
     fallback = _exclude_corpus_snapshots(
         list(config.root_path.rglob("*")), config.root_path
     )
+    fallback = _exclude_configured_globs(fallback, config.root_path, exclude_patterns)
     _repo_files_cache[key] = (fallback, False)
     return list(fallback), False
 

--- a/tests/test_config_audit_exclude.py
+++ b/tests/test_config_audit_exclude.py
@@ -1,0 +1,94 @@
+"""Tests for `[audit] exclude` glob parsing (osojicode/work#90).
+
+`.osoji.toml` may declare a project-scoped list of repo-relative exclude
+globs under `[audit] exclude`. `Config.load_audit_exclude()` reads and
+validates that list; absent file / absent table / absent-or-empty key all
+mean "no change" (empty list). Malformed shapes raise a clear RuntimeError,
+consistent with the rest of the TOML config loading in `config.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from osoji.config import Config, PROJECT_CONFIG_FILENAME
+
+
+def _write_toml(root, text: str) -> None:
+    (root / PROJECT_CONFIG_FILENAME).write_text(text, encoding="utf-8")
+
+
+def test_no_osoji_toml_returns_empty_list(temp_dir):
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == []
+
+
+def test_osoji_toml_without_audit_table_returns_empty_list(temp_dir):
+    _write_toml(temp_dir, 'default_provider = "openai"\n')
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == []
+
+
+def test_audit_table_without_exclude_key_returns_empty_list(temp_dir):
+    _write_toml(temp_dir, "[audit]\n")
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == []
+
+
+def test_empty_exclude_list_returns_empty_list(temp_dir):
+    _write_toml(temp_dir, "[audit]\nexclude = []\n")
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == []
+
+
+def test_exclude_list_is_returned_in_order(temp_dir):
+    _write_toml(
+        temp_dir,
+        '[audit]\nexclude = ["docs/archive/**", "vendor/**"]\n',
+    )
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == ["docs/archive/**", "vendor/**"]
+
+
+def test_blank_entries_are_dropped(temp_dir):
+    _write_toml(temp_dir, '[audit]\nexclude = ["docs/archive/**", "  ", ""]\n')
+    config = Config(root_path=temp_dir)
+
+    assert config.load_audit_exclude() == ["docs/archive/**"]
+
+
+def test_exclude_not_a_list_raises_runtime_error(temp_dir):
+    _write_toml(temp_dir, '[audit]\nexclude = "docs/archive/**"\n')
+    config = Config(root_path=temp_dir)
+
+    with pytest.raises(RuntimeError, match="audit.exclude"):
+        config.load_audit_exclude()
+
+
+def test_exclude_entry_not_a_string_raises_runtime_error(temp_dir):
+    _write_toml(temp_dir, "[audit]\nexclude = [1, 2]\n")
+    config = Config(root_path=temp_dir)
+
+    with pytest.raises(RuntimeError, match="audit.exclude"):
+        config.load_audit_exclude()
+
+
+def test_audit_table_not_a_table_raises_runtime_error(temp_dir):
+    _write_toml(temp_dir, 'audit = "not a table"\n')
+    config = Config(root_path=temp_dir)
+
+    with pytest.raises(RuntimeError, match=r"\[audit\]"):
+        config.load_audit_exclude()
+
+
+def test_malformed_toml_raises_runtime_error(temp_dir):
+    _write_toml(temp_dir, "not valid toml {{{\n")
+    config = Config(root_path=temp_dir)
+
+    with pytest.raises(RuntimeError, match="Invalid Osoji config file"):
+        config.load_audit_exclude()

--- a/tests/test_walker_configured_exclude.py
+++ b/tests/test_walker_configured_exclude.py
@@ -1,0 +1,195 @@
+"""Tests for the walker's `[audit] exclude` glob exclusion (osojicode/work#90).
+
+A project may declare repo-relative fnmatch globs under `.osoji.toml`'s
+`[audit] exclude` to scope expensive analysis away from low-value trees
+(e.g. a doc-heavy repo's `docs/archive/**`). This is an explicit,
+user-declared scope decision -- not a silent heuristic -- so excluded paths
+are dropped in BOTH the git ls-files discovery path and the rglob fallback,
+alongside the existing corpus-snapshot exclusion. Excluded files are never
+discovered: no shadow generation, no facts, no analysis, no findings.
+
+Matching semantics: patterns are matched via `fnmatch.fnmatch` against the
+POSIX-style path relative to the project root. `fnmatch`'s `*` already
+matches any run of characters including `/` (it has no notion of a path
+separator), so `**` behaves identically to a single `*` -- it's accepted
+for readability/familiarity with shell-glob conventions, not because it
+adds recursion `*` doesn't already have. Matching is always against the
+in-root relative path, so an absolute or `../`-prefixed pattern can never
+reach outside the project root -- it just never matches anything.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+from osoji.config import Config, PROJECT_CONFIG_FILENAME
+from osoji.walker import (
+    _exclude_configured_globs,
+    _matches_exclude_pattern,
+    clear_repo_files_cache,
+    discover_files,
+    list_repo_files,
+)
+
+
+def _write(root, rel: str, content: str = "x\n") -> None:
+    p = root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _write_exclude_config(root, patterns: list[str]) -> None:
+    def _toml_escape(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    quoted = ", ".join(f'"{_toml_escape(p)}"' for p in patterns)
+    _write(root, PROJECT_CONFIG_FILENAME, f"[audit]\nexclude = [{quoted}]\n")
+
+
+def _git_init_commit(root) -> None:
+    env_kwargs = dict(cwd=root, capture_output=True, text=True, check=True)
+    subprocess.run(["git", "init"], **env_kwargs)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], **env_kwargs)
+    subprocess.run(["git", "config", "user.name", "t"], **env_kwargs)
+    subprocess.run(["git", "add", "-A"], **env_kwargs)
+    subprocess.run(["git", "commit", "-m", "init", "--no-gpg-sign"], **env_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# unit: the pure glob matcher
+# ---------------------------------------------------------------------------
+
+
+def test_matches_exclude_pattern_simple():
+    assert _matches_exclude_pattern("docs/archive/old.md", ["docs/archive/**"]) is True
+
+
+def test_matches_exclude_pattern_no_match():
+    assert _matches_exclude_pattern("src/app.py", ["docs/archive/**"]) is False
+
+
+def test_matches_exclude_pattern_double_star_matches_nested_dirs():
+    assert (
+        _matches_exclude_pattern(
+            "docs/archive/deep/nested/old.md", ["docs/archive/**"]
+        )
+        is True
+    )
+
+
+def test_matches_exclude_pattern_dotdot_pattern_never_matches_in_root_path():
+    # A relative-to-root path never legitimately starts with "..", so a
+    # pattern trying to walk upward simply never matches anything real.
+    assert _matches_exclude_pattern("secret.py", ["../secret.py"]) is False
+
+
+def test_exclude_configured_globs_no_patterns_is_noop(temp_dir):
+    paths = [temp_dir / "a.py", temp_dir / "b.py"]
+    assert _exclude_configured_globs(paths, temp_dir, []) == paths
+
+
+def test_exclude_configured_globs_drops_matches(temp_dir):
+    keep = temp_dir / "src" / "app.py"
+    drop = temp_dir / "docs" / "archive" / "old.md"
+    result = _exclude_configured_globs([keep, drop], temp_dir, ["docs/archive/**"])
+    assert result == [keep]
+
+
+# ---------------------------------------------------------------------------
+# integration: discover_files / list_repo_files drop configured excludes,
+# both discovery paths
+# ---------------------------------------------------------------------------
+
+
+def test_discover_files_excludes_configured_globs_rglob(temp_dir):
+    """Fallback (rglob) path: respect_gitignore=False."""
+
+    _write(temp_dir, "src/app/live.py", "def live():\n    pass\n")
+    _write(temp_dir, "docs/archive/old.md", "# stale\n")
+    _write(temp_dir, "docs/archive/nested/deeper.md", "# stale too\n")
+    _write_exclude_config(temp_dir, ["docs/archive/**"])
+
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    clear_repo_files_cache()
+    files = discover_files(config)
+    rels = {f.relative_to(temp_dir).as_posix() for f in files}
+
+    assert "src/app/live.py" in rels
+    assert not any(r.startswith("docs/archive/") for r in rels)
+
+
+def test_discover_files_excludes_configured_globs_git(temp_dir):
+    """git ls-files path: respect_gitignore=True on a real git repo."""
+
+    _write(temp_dir, "src/app/live.py", "def live():\n    pass\n")
+    _write(temp_dir, "docs/archive/old.md", "# stale\n")
+    _write_exclude_config(temp_dir, ["docs/archive/**"])
+    _git_init_commit(temp_dir)
+
+    config = Config(root_path=temp_dir, respect_gitignore=True, quiet=True)
+    clear_repo_files_cache()
+    files = discover_files(config)
+    rels = {f.relative_to(temp_dir).as_posix() for f in files}
+
+    assert "src/app/live.py" in rels
+    assert not any(r.startswith("docs/archive/") for r in rels)
+
+
+def test_discover_files_keeps_non_matching_files(temp_dir):
+    _write(temp_dir, "docs/archive/old.md", "# stale\n")
+    _write(temp_dir, "docs/current/guide.md", "# current\n")
+    _write_exclude_config(temp_dir, ["docs/archive/**"])
+
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    clear_repo_files_cache()
+    files = discover_files(config)
+    rels = {f.relative_to(temp_dir).as_posix() for f in files}
+
+    assert "docs/current/guide.md" not in rels  # markdown isn't a source ext anyway
+    assert not any(r.startswith("docs/archive/") for r in rels)
+
+    # Verify at the raw discovery layer (before the doc/extension filters
+    # `discover_files` applies) that the non-matching doc file IS present
+    # and only the excluded one was dropped.
+    clear_repo_files_cache()
+    raw_paths, _ = list_repo_files(config)
+    raw_rels = {p.relative_to(temp_dir).as_posix() for p in raw_paths}
+    assert "docs/current/guide.md" in raw_rels
+    assert "docs/archive/old.md" not in raw_rels
+
+
+def test_no_exclude_config_discovers_everything(temp_dir):
+    _write(temp_dir, "src/app/live.py", "def live():\n    pass\n")
+    _write(temp_dir, "src/app/other.py", "def other():\n    pass\n")
+
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    clear_repo_files_cache()
+    files = discover_files(config)
+    rels = {f.relative_to(temp_dir).as_posix() for f in files}
+
+    assert "src/app/live.py" in rels
+    assert "src/app/other.py" in rels
+
+
+def test_absolute_or_dotdot_pattern_does_not_escape_root(temp_dir):
+    """An absolute-looking or `../`-prefixed pattern is inert, not dangerous.
+
+    Matching is always against the path relative to the project root, so
+    these patterns can't be used to reach outside the audited tree -- they
+    simply never match a real in-root file.
+    """
+
+    _write(temp_dir, "src/app/live.py", "def live():\n    pass\n")
+    escaping_absolute = str(temp_dir / "src" / "app" / "live.py")
+    _write_exclude_config(
+        temp_dir,
+        ["../../etc/passwd", "../src/app/live.py", escaping_absolute],
+    )
+
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    clear_repo_files_cache()
+    files = discover_files(config)
+    rels = {f.relative_to(temp_dir).as_posix() for f in files}
+
+    # None of the escaping patterns matched -- the real file is still found.
+    assert "src/app/live.py" in rels


### PR DESCRIPTION
## Mechanism

`.osoji.toml` can declare a project-scoped list of repo-relative exclude
globs:

\`\`\`toml
[audit]
exclude = ["docs/archive/**", "vendor/**"]
\`\`\`

`Config.load_audit_exclude()` reads and validates the `[audit].exclude` list
(mirrors the existing `.osojiignore` lazy-load pattern on `Config`; absent
file / absent table / absent key all mean "no change" — an empty list — and
a malformed shape, e.g. a non-list or non-string entries, raises a clear
`RuntimeError`, consistent with the rest of `config.py`'s TOML validation).

`walker._exclude_configured_globs()` drops every path matching those globs
from repository discovery, called from `list_repo_files()` in BOTH the
`git ls-files` path and the `rglob` fallback, alongside the existing
corpus-snapshot exclusion (`_exclude_corpus_snapshots`) — same integration
point, same style.

## Fix

Matching is via `fnmatch.fnmatch` against the path relative to the project
root. `fnmatch`'s `*` already matches any run of characters including `/`
(it has no notion of a path separator), so `**` behaves identically to a
single `*` — accepted for readability/shell-glob familiarity, not because
it adds recursion `*` lacks. Because matching is always against the in-root
relative path, an absolute or `../`-prefixed pattern can never be used to
reach outside the project root — it simply matches nothing.

Excluded files are dropped from discovery entirely: no shadow doc, no
facts, no analysis, no findings for anything under an excluded path.

**Signal-conservation framing** (per CLAUDE.md): this is not a heuristic
that could silently suppress true positives — it's an explicit,
user-declared scope decision. The config file IS the declared intent.
Language-agnostic by construction: user-supplied path patterns, no
built-in catalog, no default excludes.

## Tests

- `tests/test_config_audit_exclude.py` — TOML parsing: absent file, absent
  `[audit]` table, absent/empty `exclude` key (all → `[]`), populated list,
  blank-entry stripping, and malformed shapes (`exclude` not a list, a
  non-string entry, `[audit]` not a table, invalid TOML) each raising
  `RuntimeError`.
- `tests/test_walker_configured_exclude.py` — pure matcher unit tests
  (`_matches_exclude_pattern`, `_exclude_configured_globs`), `**` matching
  nested dirs, integration through `discover_files`/`list_repo_files` on
  both the `rglob` fallback and a real `git ls-files` repo, a no-config
  no-op case, and a path-safety case proving an absolute or `../`-prefixed
  pattern can't escape the project root.

Targeted: `PYTHONPATH=src python -m pytest tests/test_config_audit_exclude.py tests/test_walker_configured_exclude.py tests/test_walker_corpus_exclusion.py -q` → 29 passed.

Full suite (mirroring CI's `pytest -m "not prompt_regression and not live_smoke"`, no API calls): 1442 passed, 10 skipped, 11 deselected.

Docs updated: README.md (`## Configuration`), `docs/explanatory/shadow-documentation-architecture.md` (Stage 1: File discovery), `CHANGELOG.md`.

Ref: `osojicode/work#90`

🤖 Generated with [Claude Code](https://claude.com/claude-code)