### PR TITLE
fail fast on billing errors and always serialize audit results (Fixes #160)

### DIFF
--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -27,6 +27,8 @@ from .shadow import check_shadow_docs, generate_shadow_docs_async
 from .doc_analysis import analyze_docs_async
 from .junk_cicd import discover_cicd_files
 from .llm.runtime import create_runtime
+from .llm.errors import ProviderCircuitBreaker, classify_permanent_error
+from .llm.types import ProviderPermanentError
 from .scorecard import CoverageEntry, JunkCodeEntry, Scorecard, build_scorecard
 from .walker import _matches_ignore
 # V1-3: Phase 3 debris verification runs through the unified Triage stage. The
@@ -184,6 +186,44 @@ def _record_degradation(config: Config, phase: str, exc: Exception) -> None:
     degradations = getattr(config, "audit_degradations", None)
     if degradations is not None:
         degradations.append({"phase": phase, "error": str(exc)})
+
+
+def _phase_result_or_degrade(config: Config, phase: str, outcome: Any, default: Any) -> Any:
+    """Unwrap a ``return_exceptions`` gather result, degrading on failure.
+
+    A phase that raised (an unhandled provider/analysis error escaping its own
+    best-effort handling) is recorded as degraded and its empty ``default`` is
+    substituted so the rest of the audit still serializes. A permanent
+    (billing/auth) failure also trips the shared circuit breaker (belt and
+    suspenders — the provider layer normally trips it first).
+    """
+    if isinstance(outcome, BaseException):
+        if not isinstance(outcome, Exception):
+            raise outcome  # never swallow KeyboardInterrupt/CancelledError
+        permanent = classify_permanent_error(outcome)
+        breaker = getattr(config, "provider_circuit_breaker", None)
+        if permanent is not None and breaker is not None:
+            breaker.trip(permanent)
+        _record_degradation(config, phase, outcome)
+        return default
+    return outcome
+
+
+def _note_breaker_degradation(config: Config, phase: str) -> None:
+    """Record ``phase`` as degraded when the shared circuit breaker is tripped.
+
+    decide_junk_claims absorbs a permanent (billing/auth) error to keep its
+    findings (best-effort) rather than raising, so the phase's own ``except``
+    never fires. This attributes the tripped breaker to the phase that ran the
+    doomed LLM work, once — so degraded_phases names it. Idempotent per phase.
+    """
+    breaker = getattr(config, "provider_circuit_breaker", None)
+    if breaker is None or not breaker.tripped:
+        return
+    degradations = getattr(config, "audit_degradations", None)
+    if degradations is None or any(d["phase"] == phase for d in degradations):
+        return
+    degradations.append({"phase": phase, "error": str(breaker.error)})
 
 
 def _degraded_phases(config: Config) -> list[str] | None:
@@ -418,6 +458,11 @@ async def run_audit_async(
     # decided findings here (see triage.py); serialized below as the
     # decided-findings ledger that `osoji corpus emit` reads.
     config.decided_ledger = []
+    # #160: shared circuit breaker. create_runtime hands it to every phase's
+    # provider; the first permanent (billing/auth) error trips it so remaining
+    # LLM work short-circuits, and the run still reaches the terminal
+    # serialization path before exiting nonzero with the billing cause.
+    config.provider_circuit_breaker = ProviderCircuitBreaker()
 
     # Shared rate limiter across all phases so token budgets are tracked globally
     rate_limiter = RateLimiter(get_config_with_overrides(config.provider or "anthropic"))
@@ -490,9 +535,19 @@ async def run_audit_async(
     phase3_5_coro = _run_phase3_5_async(config, obligations and not skip_obligations, rate_limiter, verbose)
     phase4_coro = _noop_phase4() if not enabled_flags else _run_phase4_async(config, rate_limiter, enabled_flags, progress_cb, verbose)
 
-    phase2_raw, phase3_raw, phase3_5_raw, phase4_raw = (
-        await asyncio.gather(phase2_coro, phase3_coro, phase3_5_coro, phase4_coro)
+    # #160: gather with return_exceptions so one phase crashing (e.g. an
+    # unhandled provider error in doc-analysis or a junk analyzer) never aborts
+    # the run before serialization — the crashed phase is recorded as degraded
+    # and substituted with its empty default so every other phase's completed
+    # work is still collected and serialized below.
+    gathered = await asyncio.gather(
+        phase2_coro, phase3_coro, phase3_5_coro, phase4_coro,
+        return_exceptions=True,
     )
+    phase2_raw = _phase_result_or_degrade(config, "doc-analysis", gathered[0], ([], (0, 0)))
+    phase3_raw = _phase_result_or_degrade(config, "debris", gathered[1], (set(), (0, 0), {}))
+    phase3_5_raw = _phase_result_or_degrade(config, "obligations", gathered[2], ([], (0, 0), 0, 0))
+    phase4_raw = _phase_result_or_degrade(config, "junk", gathered[3], ({}, {}))
     analysis_results, phase2_tokens = phase2_raw
     debris_result, phase3_tokens, debris_decided = phase3_raw
     obligation_findings, phase3_5_tokens, contract_triaged, contract_other = phase3_5_raw
@@ -793,6 +848,15 @@ async def run_audit_async(
         "findings": config.decided_ledger,
     })
 
+    # #160: everything above serialized this run's completed analysis (audit
+    # result, scorecard with degraded_phases, decided-findings ledger). Only
+    # now, with the terminal path done, surface a permanent provider failure so
+    # the CLI exits nonzero with a message naming the billing/auth cause instead
+    # of returning a silently-partial success.
+    breaker = getattr(config, "provider_circuit_breaker", None)
+    if breaker is not None and breaker.tripped:
+        raise breaker.error
+
     return result
 
 
@@ -899,6 +963,9 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
                 rate = would_escalate / eligible_total if eligible_total else 0.0
                 _emit(config, f"  {would_escalate} eligible finding(s) lacked gatherable evidence "
                               f"(would-escalate; kept unverified; escalation rate {rate:.1%})")
+            # #160: decide_junk_claims absorbs a permanent error to keep findings
+            # (it never raises here), so attribute a tripped breaker to this phase.
+            _note_breaker_degradation(config, "debris-triage")
         except Exception as exc:
             # Triage is best-effort; on failure, keep all findings — but the
             # degradation must be recorded and visible.
@@ -994,6 +1061,9 @@ async def _run_phase3_5_async(config, obligations_enabled, rate_limiter, verbose
                 if df.verdict == "dismissed":
                     continue                                # dismissed = false positive -> suppress
                 kept.append(_overlay_verdict(cf, df))       # confirmed OR unverified(None) kept
+            # #160: decide_junk_claims absorbs a permanent error to keep findings
+            # (it never raises here), so attribute a tripped breaker to this phase.
+            _note_breaker_degradation(config, "obligations-triage")
         except Exception as exc:
             kept = contract_findings                        # best-effort: keep all, unverified
             _record_degradation(config, "obligations-triage", exc)

--- a/src/osoji/junk_triage.py
+++ b/src/osoji/junk_triage.py
@@ -33,6 +33,7 @@ from .claim_builder import build_claims
 from .config import Config
 from .evidence_builders import BuildContext
 from .findings import Finding
+from .llm.errors import classify_permanent_error
 from .triage import TRIAGE_SYSTEM_PROMPT, Claim, Triage
 
 #: Max claims per Triage call. V1-4 measured 12 claims/call as reliable on the
@@ -74,6 +75,10 @@ async def decide_junk_claims(
     # cache short-circuits Triage for unchanged findings and its harvest
     # collects decided verdicts for the audit-manifest rewrite.
     session = getattr(config, "verdict_session", None)
+    # #160: the orchestrator may attach a shared circuit breaker. Once a
+    # permanent (billing/auth) error trips it, remaining chunks short-circuit
+    # (kept undecided) instead of issuing calls that will fail identically.
+    breaker = getattr(config, "provider_circuit_breaker", None)
 
     # Keep same-file claims adjacent (shared context reads batch better), then
     # pack greedily into bounded chunks; chunks may span files — claims are
@@ -91,6 +96,11 @@ async def decide_junk_claims(
     lock = asyncio.Lock()
 
     async def decide(indices: list[int], *, allow_bisect: bool = True) -> None:
+        # Circuit already open: don't issue a doomed call; keep undecided.
+        if breaker is not None and breaker.tripped:
+            for i in indices:
+                results[i] = claims[i].finding
+            return
         chunk = [claims[i] for i in indices]
         try:
             batch = await triage.decide_batch(
@@ -100,6 +110,15 @@ async def decide_junk_claims(
                 verdict_cache=session.cache if session is not None else None,
             )
         except Exception as exc:
+            # A permanent (billing/auth) failure will recur on every retry:
+            # trip the breaker and keep this chunk undecided without bisecting.
+            permanent = classify_permanent_error(exc)
+            if permanent is not None:
+                if breaker is not None:
+                    breaker.trip(permanent)
+                for i in indices:
+                    results[i] = claims[i].finding
+                return
             if allow_bisect and len(indices) > 1:
                 mid = len(indices) // 2
                 await decide(indices[:mid], allow_bisect=False)

--- a/src/osoji/llm/errors.py
+++ b/src/osoji/llm/errors.py
@@ -1,0 +1,167 @@
+"""Permanent-provider-error classification and the audit circuit breaker.
+
+Billing/credit exhaustion and auth failures are not transient: every retry
+against the same account fails identically. :func:`classify_permanent_error`
+turns the raw SDK error into a typed :class:`ProviderPermanentError`;
+:class:`ProviderCircuitBreaker` is the shared latch the audit orchestrator trips
+on the first one so the remaining LLM work short-circuits instead of burning
+wall-clock on doomed calls (osoji issue #160).
+
+Detection prefers structured type/code/status fields the SDKs expose. The one
+place string matching is unavoidable is the anthropic billing 400: it shares
+its status code (400) and error type (``invalid_request_error``) with ordinary
+malformed requests, so the only reliable signal is the message. That matching
+is scoped narrowly — a small set of billing-specific phrases, and only on
+client (4xx) errors — so transient failures keep their existing retry path.
+"""
+
+from __future__ import annotations
+
+from .types import ProviderPermanentError
+
+# Billing-specific phrases. Deliberately narrow: each is a settled billing
+# phrase that does not appear in transient or rate-limit error text.
+_BILLING_MARKERS: tuple[str, ...] = (
+    "credit balance",
+    "too low to access",
+    "purchase credits",
+    "plan and billing",
+    "billing details",
+    "insufficient_quota",
+    "insufficient funds",
+)
+
+# SDK exception type names that are always permanent regardless of status.
+_AUTH_TYPE_NAMES: frozenset[str] = frozenset({
+    "AuthenticationError",
+    "PermissionDeniedError",
+})
+
+
+def _status_code(exc: BaseException) -> int | None:
+    code = getattr(exc, "status_code", None)
+    if isinstance(code, int):
+        return code
+    response = getattr(exc, "response", None)
+    code = getattr(response, "status_code", None)
+    return code if isinstance(code, int) else None
+
+
+def _error_code(exc: BaseException) -> str | None:
+    code = getattr(exc, "code", None)
+    if isinstance(code, str):
+        return code
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict) and isinstance(err.get("code"), str):
+            return err["code"]
+    return None
+
+
+def _detail(exc: BaseException) -> str:
+    """Cleanest single-line human detail available for the error."""
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict) and isinstance(err.get("message"), str) and err["message"].strip():
+            return err["message"].strip().splitlines()[0]
+    message = getattr(exc, "message", None)
+    if isinstance(message, str) and message.strip():
+        return message.strip().splitlines()[0]
+    text = str(exc).strip()
+    return text.splitlines()[0] if text else exc.__class__.__name__
+
+
+def _search_text(exc: BaseException) -> str:
+    parts = [str(exc)]
+    message = getattr(exc, "message", None)
+    if isinstance(message, str):
+        parts.append(message)
+    body = getattr(exc, "body", None)
+    if isinstance(body, dict):
+        err = body.get("error")
+        if isinstance(err, dict) and isinstance(err.get("message"), str):
+            parts.append(err["message"])
+    return " ".join(parts).lower()
+
+
+def _provider_hint(exc: BaseException) -> str | None:
+    module = (exc.__class__.__module__ or "").split(".")[0]
+    if module in {"anthropic", "openai", "google"}:
+        return module
+    return None
+
+
+def _message(exc: BaseException, kind: str) -> str:
+    provider = _provider_hint(exc)
+    prefix = f"{provider} " if provider else ""
+    return (
+        f"{prefix}permanent {kind} failure — remaining LLM calls will fail "
+        f"identically: {_detail(exc)[:200]}"
+    )
+
+
+def classify_permanent_error(exc: BaseException) -> ProviderPermanentError | None:
+    """Classify ``exc`` as a permanent provider failure, or ``None``.
+
+    Returns a :class:`ProviderPermanentError` for billing/credit exhaustion and
+    auth/permission failures (which every retry reproduces); returns ``None``
+    for everything else — transient errors, malformed requests, rate limits —
+    so their existing type and handling are preserved.
+    """
+    if isinstance(exc, ProviderPermanentError):
+        return exc
+
+    status = _status_code(exc)
+    type_name = type(exc).__name__
+
+    # Auth / permission: never transient.
+    if status in (401, 403) or type_name in _AUTH_TYPE_NAMES:
+        return ProviderPermanentError(
+            _message(exc, "auth"),
+            reason="auth",
+            provider=_provider_hint(exc),
+            status_code=status,
+        )
+
+    # Billing / quota exhaustion. Structured code first (openai), then the
+    # narrow anthropic message markers — but only for client (4xx) errors so a
+    # stray marker on a 5xx keeps its transient retry path.
+    is_billing = _error_code(exc) == "insufficient_quota" or any(
+        marker in _search_text(exc) for marker in _BILLING_MARKERS
+    )
+    if is_billing and (status is None or 400 <= status < 500):
+        return ProviderPermanentError(
+            _message(exc, "billing"),
+            reason="billing",
+            provider=_provider_hint(exc),
+            status_code=status,
+        )
+
+    return None
+
+
+class ProviderCircuitBreaker:
+    """First-permanent-error latch shared by every phase of one audit run.
+
+    Async use here is single-threaded and cooperative: ``trip`` and ``tripped``
+    never ``await``, so the read-modify-write is atomic between suspension
+    points — no lock is needed. First writer wins (idempotent): the recorded
+    error is the one surfaced to the CLI as the run's cause of death.
+    """
+
+    def __init__(self) -> None:
+        self._error: ProviderPermanentError | None = None
+
+    @property
+    def tripped(self) -> bool:
+        return self._error is not None
+
+    @property
+    def error(self) -> ProviderPermanentError | None:
+        return self._error
+
+    def trip(self, error: ProviderPermanentError) -> None:
+        if self._error is None:
+            self._error = error

--- a/src/osoji/llm/rate_limited.py
+++ b/src/osoji/llm/rate_limited.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 from ..rate_limiter import RateLimiter
 from .base import LLMProvider
+from .errors import ProviderCircuitBreaker, classify_permanent_error
 from .tokens import TokenCounter, estimate_tokens_offline
 from .types import CompletionOptions, CompletionResult, Message, RateLimitMetadata
 
@@ -34,10 +35,16 @@ class RateLimitedProvider(LLMProvider):
         rate_limiter: RateLimiter,
         *,
         token_counter: TokenCounter | None = None,
+        circuit_breaker: ProviderCircuitBreaker | None = None,
     ) -> None:
         self._provider = provider
         self._rate_limiter = rate_limiter
         self._token_counter = token_counter
+        # Optional shared latch: once a permanent (billing/auth) error is seen,
+        # every subsequent call short-circuits instead of issuing a doomed
+        # request. None outside the multi-phase audit (create_runtime supplies
+        # one only when the orchestrator attached it to config).
+        self._circuit_breaker = circuit_breaker
 
     @property
     def name(self) -> str:
@@ -51,6 +58,11 @@ class RateLimitedProvider(LLMProvider):
     ) -> CompletionResult:
         reservation_key = options.reservation_key or "default"
         retry_count = 0
+
+        # Circuit open: a prior call already hit a permanent failure. Fail fast
+        # without reserving budget or issuing another doomed request.
+        if self._circuit_breaker is not None and self._circuit_breaker.tripped:
+            raise self._circuit_breaker.error
 
         while True:
             estimated_input_tokens = await self._estimate_input_tokens(
@@ -75,6 +87,14 @@ class RateLimitedProvider(LLMProvider):
             except Exception as exc:
                 if not self._is_retryable_error(exc):
                     await self._rate_limiter.finalize_failure(ticket, is_rate_limit=False)
+                    # Billing/auth-class failures are permanent: raise the typed
+                    # error and trip the shared breaker so the rest of the run
+                    # short-circuits rather than retrying identically-doomed calls.
+                    permanent = classify_permanent_error(exc)
+                    if permanent is not None:
+                        if self._circuit_breaker is not None:
+                            self._circuit_breaker.trip(permanent)
+                        raise permanent from exc
                     raise
                 retry_after = self._extract_retry_after(exc) or min(30.0, float(2 ** retry_count))
                 await self._rate_limiter.finalize_failure(

--- a/src/osoji/llm/runtime.py
+++ b/src/osoji/llm/runtime.py
@@ -35,6 +35,9 @@ def create_runtime(
         provider,
         resolved_rate_limiter,
         token_counter=token_counter,
+        # The audit orchestrator attaches a shared breaker to config so every
+        # phase's provider short-circuits after the first permanent error.
+        circuit_breaker=getattr(config, "provider_circuit_breaker", None),
     )
     logging_provider = LoggingProvider(rate_limited_provider, verbose=verbose)
     return logging_provider, resolved_rate_limiter

--- a/src/osoji/llm/types.py
+++ b/src/osoji/llm/types.py
@@ -61,6 +61,30 @@ class PromptTooLargeError(RuntimeError):
         )
 
 
+class ProviderPermanentError(RuntimeError):
+    """Raised when a provider fails permanently — every retry fails identically.
+
+    Billing/credit exhaustion and auth/permission failures are not transient:
+    once seen, every subsequent call to the same account fails the same way.
+    Classifying them into this typed error lets the audit orchestrator trip a
+    circuit breaker and skip the remaining LLM work instead of burning
+    wall-clock on doomed calls (see osoji issue #160).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: str,
+        provider: str | None = None,
+        status_code: int | None = None,
+    ) -> None:
+        self.reason = reason  # "billing" | "auth"
+        self.provider = provider
+        self.status_code = status_code
+        super().__init__(message)
+
+
 class ToolSchemaValidationError(RuntimeError):
     """Raised when a forced tool call stays invalid after all retry attempts."""
 

--- a/tests/test_audit_billing_fail_fast.py
+++ b/tests/test_audit_billing_fail_fast.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for billing/credit fail-fast serialization (issue #160).
+
+When the provider dies mid-audit with a permanent billing/credit error, the
+run must not discard all completed analysis. The circuit breaker trips on the
+first permanent error, the terminal serialization path still runs (so
+``audit-result.json`` exists and ``osoji report`` works), the affected phase is
+named in ``degraded_phases``, and the run exits nonzero with a message naming
+the billing cause instead of crashing with an unhandled SDK error.
+
+Molded on ``test_audit_degradation.py`` (real ``run_audit_async`` orchestration
+with a canned provider injected through ``osoji.audit.create_runtime``).
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from osoji.audit import run_audit_async
+from osoji.config import Config
+from osoji.llm.types import CompletionResult, ProviderPermanentError, ToolCall
+
+
+def _write(temp_dir: Path, rel: str, text: str) -> None:
+    path = temp_dir / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_facts(temp_dir: Path, source: str, string_literals: list[dict]) -> None:
+    facts_file = temp_dir / ".osoji" / "facts" / (source + ".facts.json")
+    facts_file.parent.mkdir(parents=True, exist_ok=True)
+    facts_file.write_text(json.dumps({
+        "source": source,
+        "source_hash": "abc123",
+        "imports": [],
+        "exports": [],
+        "calls": [],
+        "string_literals": string_literals,
+    }), encoding="utf-8")
+
+
+def _one_implicit_contract_env(temp_dir: Path) -> None:
+    _write(temp_dir, "src/producer.py", "def emit():\n    return 'my_category'\n")
+    _write(temp_dir, "src/consumer.py", "def handle(x):\n    return x == 'my_category'\n")
+    _write_facts(temp_dir, "src/producer.py", [
+        {"value": "my_category", "context": "appended to list", "line": 2,
+         "kind": "identifier", "usage": "produced"},
+    ])
+    _write_facts(temp_dir, "src/consumer.py", [
+        {"value": "my_category", "context": "membership check", "line": 2,
+         "kind": "identifier", "usage": "checked"},
+    ])
+
+
+class _BillingError(Exception):
+    """Stand-in for anthropic's billing 400 (credit balance too low)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Error code: 400 - Your credit balance is too low to access the "
+            "Anthropic API."
+        )
+        self.status_code = 400
+        self.message = str(self)
+
+
+class _BillingProvider:
+    """Raises a raw billing-class SDK error on every completion."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def complete(self, messages, system, options):
+        self.calls += 1
+        raise _BillingError()
+
+    async def close(self):
+        pass
+
+
+class _OkProvider:
+    """Succeeds — used to prove the clean path is untouched."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def complete(self, messages, system, options):
+        self.calls += 1
+        validator = options.tool_input_validators[0]
+        n = len(validator("submit_triage_verdicts", {"verdicts": []}))
+        verdicts = [
+            {"batch_index": i, "verdict": "confirmed", "confidence": 0.9,
+             "reasoning": "genuine"}
+            for i in range(n)
+        ]
+        return CompletionResult(
+            content=None,
+            tool_calls=[ToolCall(id=f"tc{self.calls}", name="submit_triage_verdicts",
+                                 input={"verdicts": verdicts})],
+            input_tokens=100, output_tokens=50, model="test", stop_reason="tool_use",
+        )
+
+    async def close(self):
+        pass
+
+
+_OBLIGATIONS_EXCLUDE = {"shadow", "doc-analysis", "debris"}
+
+
+def test_billing_error_serializes_result_and_exits_nonzero(temp_dir):
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = _BillingProvider()
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        with pytest.raises(ProviderPermanentError) as exc_info:
+            asyncio.run(run_audit_async(
+                config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+            ))
+
+    # The run exits nonzero with a message naming the billing cause.
+    assert exc_info.value.reason == "billing"
+    assert "billing" in str(exc_info.value).lower()
+
+    # The terminal serialization path ran even though a phase hit the error.
+    result_path = temp_dir / ".osoji" / "analysis" / "audit-result.json"
+    assert result_path.exists()
+    scorecard_path = temp_dir / ".osoji" / "analysis" / "scorecard.json"
+    assert scorecard_path.exists()
+    ledger_path = temp_dir / ".osoji" / "analysis" / "decided-findings.json"
+    assert ledger_path.exists()
+
+    # The affected phase is named in degraded_phases (persisted to disk).
+    scorecard = json.loads(scorecard_path.read_text(encoding="utf-8"))
+    assert scorecard["degraded_phases"] is not None
+    assert "obligations-triage" in scorecard["degraded_phases"]
+
+    # config records the degradation for the same phase.
+    phases = {d["phase"] for d in config.audit_degradations}
+    assert "obligations-triage" in phases
+
+    # The heuristic obligation finding is preserved in the serialized result
+    # (kept unverified, not discarded).
+    audit_result = json.loads(result_path.read_text(encoding="utf-8"))
+    obligation_issues = [
+        i for i in audit_result["issues"] if i.get("exclude_key") == "obligations"
+    ]
+    assert len(obligation_issues) == 1
+
+
+def test_breaker_trips_and_short_circuits_within_phase(temp_dir):
+    # Two independent contracts -> two claims. The first triage call trips the
+    # breaker; the circuit stays open, so the provider is not called once per
+    # claim indefinitely. (Best-effort: findings are kept, run still serializes.)
+    _write(temp_dir, "src/producer.py",
+           "def emit():\n    return 'cat_a'\n\ndef emit2():\n    return 'cat_b'\n")
+    _write(temp_dir, "src/consumer.py",
+           "def handle(x):\n    return x == 'cat_a'\n\ndef h2(y):\n    return y == 'cat_b'\n")
+    _write_facts(temp_dir, "src/producer.py", [
+        {"value": "cat_a", "context": "appended", "line": 2, "kind": "identifier", "usage": "produced"},
+        {"value": "cat_b", "context": "appended", "line": 5, "kind": "identifier", "usage": "produced"},
+    ])
+    _write_facts(temp_dir, "src/consumer.py", [
+        {"value": "cat_a", "context": "membership", "line": 2, "kind": "identifier", "usage": "checked"},
+        {"value": "cat_b", "context": "membership", "line": 5, "kind": "identifier", "usage": "checked"},
+    ])
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = _BillingProvider()
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        with pytest.raises(ProviderPermanentError):
+            asyncio.run(run_audit_async(
+                config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+            ))
+
+    breaker = config.provider_circuit_breaker
+    assert breaker.tripped
+    # audit-result.json still written despite the mid-run failure.
+    assert (temp_dir / ".osoji" / "analysis" / "audit-result.json").exists()
+
+
+def test_clean_run_never_trips_breaker(temp_dir):
+    _one_implicit_contract_env(temp_dir)
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = _OkProvider()
+
+    with patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, obligations=True, exclude=_OBLIGATIONS_EXCLUDE,
+        ))
+
+    assert not config.provider_circuit_breaker.tripped
+    assert config.audit_degradations == []
+    assert result.scorecard.degraded_phases is None

--- a/tests/test_llm_permanent_error.py
+++ b/tests/test_llm_permanent_error.py
@@ -1,0 +1,222 @@
+"""Tests for permanent-provider-error classification and the circuit breaker.
+
+Billing/credit exhaustion and auth failures are not transient: every retry
+fails identically. ``classify_permanent_error`` turns the raw SDK error into a
+typed :class:`ProviderPermanentError`, and ``RateLimitedProvider`` trips a
+shared :class:`ProviderCircuitBreaker` on the first one so the remaining LLM
+work short-circuits instead of burning wall-clock (osoji issue #160).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+import pytest
+
+from osoji.llm.base import LLMProvider
+from osoji.llm.errors import ProviderCircuitBreaker, classify_permanent_error
+from osoji.llm.rate_limited import RateLimitedProvider
+from osoji.llm.types import (
+    CompletionOptions,
+    CompletionResult,
+    Message,
+    MessageRole,
+    ProviderPermanentError,
+)
+from osoji.rate_limiter import RateLimiter, RateLimiterConfig
+
+
+# --- test doubles for SDK errors ----------------------------------------------
+
+
+class _FakeStatusError(Exception):
+    """Stand-in for an SDK APIStatusError: carries status_code + message/body."""
+
+    def __init__(self, message: str, *, status_code: int, body: dict | None = None,
+                 code: str | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.body = body
+        self.code = code
+
+
+def _billing_400() -> _FakeStatusError:
+    return _FakeStatusError(
+        "Error code: 400 - Your credit balance is too low to access the "
+        "Anthropic API. You can go to Plans & Billing to upgrade or purchase credits.",
+        status_code=400,
+    )
+
+
+def _malformed_400() -> _FakeStatusError:
+    return _FakeStatusError(
+        "Error code: 400 - messages: at least one message is required",
+        status_code=400,
+    )
+
+
+# --- classification ------------------------------------------------------------
+
+
+def test_billing_400_is_classified_permanent():
+    result = classify_permanent_error(_billing_400())
+    assert isinstance(result, ProviderPermanentError)
+    assert result.reason == "billing"
+    assert result.status_code == 400
+
+
+def test_ordinary_malformed_400_is_not_permanent():
+    assert classify_permanent_error(_malformed_400()) is None
+
+
+def test_auth_401_is_classified_permanent():
+    result = classify_permanent_error(
+        _FakeStatusError("invalid x-api-key", status_code=401)
+    )
+    assert isinstance(result, ProviderPermanentError)
+    assert result.reason == "auth"
+
+
+def test_permission_403_is_classified_permanent():
+    result = classify_permanent_error(
+        _FakeStatusError("permission denied", status_code=403)
+    )
+    assert isinstance(result, ProviderPermanentError)
+    assert result.reason == "auth"
+
+
+def test_openai_insufficient_quota_code_is_billing():
+    exc = _FakeStatusError(
+        "You exceeded your current quota, please check your plan and billing details.",
+        status_code=429,
+        code="insufficient_quota",
+    )
+    result = classify_permanent_error(exc)
+    assert isinstance(result, ProviderPermanentError)
+    assert result.reason == "billing"
+
+
+def test_transient_500_is_not_permanent():
+    assert classify_permanent_error(
+        _FakeStatusError("internal server error", status_code=500)
+    ) is None
+
+
+def test_generic_runtime_error_is_not_permanent():
+    assert classify_permanent_error(RuntimeError("boom")) is None
+
+
+def test_already_typed_error_passes_through():
+    original = ProviderPermanentError("dead", reason="billing")
+    assert classify_permanent_error(original) is original
+
+
+def test_billing_marker_on_5xx_stays_transient():
+    # A stray marker on a server error must not be latched as permanent.
+    exc = _FakeStatusError("credit balance service unavailable", status_code=503)
+    assert classify_permanent_error(exc) is None
+
+
+# --- circuit breaker -----------------------------------------------------------
+
+
+def test_circuit_breaker_latches_first_error():
+    breaker = ProviderCircuitBreaker()
+    assert not breaker.tripped
+    first = ProviderPermanentError("first", reason="billing")
+    breaker.trip(first)
+    assert breaker.tripped
+    assert breaker.error is first
+    # idempotent: a later trip does not overwrite the first-seen cause.
+    breaker.trip(ProviderPermanentError("second", reason="auth"))
+    assert breaker.error is first
+
+
+# --- RateLimitedProvider integration ------------------------------------------
+
+
+class _SequenceProvider(LLMProvider):
+    def __init__(self, responses):
+        self._responses = deque(responses)
+        self.calls = 0
+
+    @property
+    def name(self) -> str:
+        return "anthropic"
+
+    async def complete(self, messages, system, options):
+        self.calls += 1
+        response = self._responses.popleft()
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def close(self):
+        pass
+
+
+def _limiter() -> RateLimiter:
+    return RateLimiter(RateLimiterConfig(
+        requests_per_minute=600000,
+        input_tokens_per_minute=1_000_000,
+        output_tokens_per_minute=1_000_000,
+        name="test",
+    ))
+
+
+def _ok() -> CompletionResult:
+    return CompletionResult(
+        content="ok", tool_calls=[], input_tokens=10, output_tokens=5,
+        model="test", stop_reason="end_turn",
+    )
+
+
+def _options() -> CompletionOptions:
+    return CompletionOptions(model="test-model", max_tokens=64, reservation_key="k")
+
+
+def test_provider_raises_typed_error_and_trips_breaker():
+    breaker = ProviderCircuitBreaker()
+    provider = _SequenceProvider([_billing_400(), _ok()])
+    wrapped = RateLimitedProvider(provider, _limiter(), circuit_breaker=breaker)
+
+    async def run():
+        with pytest.raises(ProviderPermanentError) as exc_info:
+            await wrapped.complete(
+                [Message(role=MessageRole.USER, content="hi")], None, _options(),
+            )
+        assert exc_info.value.reason == "billing"
+        # Second call short-circuits: the underlying provider is NOT called
+        # again after the breaker trips.
+        with pytest.raises(ProviderPermanentError):
+            await wrapped.complete(
+                [Message(role=MessageRole.USER, content="hi")], None, _options(),
+            )
+
+    asyncio.run(run())
+    assert breaker.tripped
+    assert provider.calls == 1  # one real call, then short-circuit
+
+
+def test_malformed_400_is_not_latched():
+    breaker = ProviderCircuitBreaker()
+    provider = _SequenceProvider([_malformed_400(), _ok()])
+    wrapped = RateLimitedProvider(provider, _limiter(), circuit_breaker=breaker)
+
+    async def run():
+        # Ordinary 400 keeps its original type and does NOT trip the breaker.
+        with pytest.raises(_FakeStatusError):
+            await wrapped.complete(
+                [Message(role=MessageRole.USER, content="hi")], None, _options(),
+            )
+        # A later call still goes through to the provider (no circuit open).
+        result = await wrapped.complete(
+            [Message(role=MessageRole.USER, content="hi")], None, _options(),
+        )
+        assert result.content == "ok"
+
+    asyncio.run(run())
+    assert not breaker.tripped
+    assert provider.calls == 2


### PR DESCRIPTION
## Mechanism

Mid-audit credit exhaustion made the provider return `400 invalid_request_error` ("credit balance is too low") on every call. Per-chunk triage logged failures and continued — burning wall-clock on guaranteed-to-fail calls — and the run finally died on an unhandled `anthropic.BadRequestError` **without serializing `audit-result.json`**. The whole run's completed analysis was lost (`osoji report` → "No cached audit result"). See #160.

## Fix

Two independent hardenings.

**1. Typed permanent-failure classification (LLM layer).** `llm/errors.classify_permanent_error` turns billing/credit/auth-class SDK errors into a typed `ProviderPermanentError` (`llm/types.py`). Detection prefers structured `status_code`/type/`code` fields (401/403 and SDK auth types → auth; openai `insufficient_quota` → billing). String matching is the last resort only for the anthropic billing 400, which shares its status code (400) and error type (`invalid_request_error`) with ordinary malformed requests — so it is scoped to a narrow set of billing phrases and to 4xx client errors. Ordinary malformed 400s and transient 5xx stay unclassified and keep their existing retry path.

**2. Circuit breaker + serialize-on-fatal (orchestrator).** A shared `ProviderCircuitBreaker` (attached to `config`, handed to every phase's provider via `create_runtime`) trips on the first `ProviderPermanentError`. `RateLimitedProvider` and the chunked triage driver (`decide_junk_claims`) then short-circuit remaining LLM work instead of retrying identically-doomed calls. The audit orchestrator gathers phases with `return_exceptions=True`, so a phase that raises is recorded as degraded and the run always reaches the terminal serialization path (`audit-result.json`, scorecard with `degraded_phases`, decided-findings ledger). It then re-raises the typed error so the CLI exits nonzero with a one-line message naming the billing cause (`ProviderPermanentError` is a `RuntimeError`, caught by the audit command's existing handler).

## Tests

- `tests/test_llm_permanent_error.py` — classification (billing 400 → typed; malformed 400 → not permanent; 401/403 → auth; openai `insufficient_quota` → billing; stray marker on 5xx stays transient; already-typed pass-through) and `RateLimitedProvider` short-circuit (asserts the underlying provider is not called again after the breaker trips).
- `tests/test_audit_billing_fail_fast.py` — full `run_audit_async`: a mid-phase billing error trips the breaker, `audit-result.json`/scorecard/ledger are all written, `degraded_phases` names the affected phase, the run raises with a billing message, and heuristic findings are preserved. Plus a clean-run guard proving the breaker never trips on success.

Full suite green (`pytest -m "not prompt_regression and not live_smoke and not corpus_evaluate"`): 1436 passed, 10 skipped. No live/LLM tests run; no API spend.

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)