### PR TITLE
ratchet ce_gap_gap_type bound to 0.25

### DIFF
--- a/tests/fixtures/prompt_regression/evaluate-baseline.json
+++ b/tests/fixtures/prompt_regression/evaluate-baseline.json
@@ -12,7 +12,7 @@
     "max": 0.05
   },
   "ce_gap_gap_type": {
-    "max": 0.45
+    "max": 0.25
   },
   "ce_gap_contract_other": {
     "max": 0.1


### PR DESCRIPTION
Static-bound ratchet per the falsifiability page's ratchet-down rule: post-repair measurement is 0.2206 (run eval-20260722-83ede491, after #158 corrected 14 migration-mislabeled cases), so the bound moves from 0.45 to just above measurement. Ratified with the latent-bug routing ruling (osojicode/work#35 thread). Static corpus tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)