### PR TITLE
let Triage assign the latent-bug gap_type split for parked claims

### DIFF
--- a/src/osoji/audit_manifest.py
+++ b/src/osoji/audit_manifest.py
@@ -170,6 +170,9 @@ class VerdictSession:
                 "suggested_fix": finding.suggested_fix,
                 "severity": finding.severity,
                 "contract_class": finding.contract_class,
+                # LLM-assigned split for parked claims (decisions/0025);
+                # _apply_cached re-applies it under the same only-if-parked guard.
+                "gap_type": finding.gap_type,
             }
 
     @property

--- a/src/osoji/tools.py
+++ b/src/osoji/tools.py
@@ -1032,6 +1032,16 @@ _TRIAGE_VERDICT_FIELDS = {
                        "literal. Emit 'other' when no class fits — a request for review, never "
                        "shoehorned into the nearest class. Omit for non-contract claims.",
     },
+    "gap_type": {
+        "type": "string",
+        "enum": ["description", "contract", "uncategorized"],
+        "description": "Claims whose header shows [uncategorized] only: which invariant "
+                       "class the claim's (alleged) gap violates — 'description' when the "
+                       "invariant is stated in an artifact (comment, docstring, type, doc), "
+                       "'contract' when it is an implicit cross-component agreement, "
+                       "'uncategorized' when neither can be stated. Omit for claims whose "
+                       "gap type is already known; such values are ignored.",
+    },
 }
 
 

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -227,6 +227,12 @@ the evidence genuinely cannot decide. A deliberately pinned value asserted in
 a test-role file (a snapshot pin, a golden value, a self-test expectation) is
 a guard doing its job, not a magic-number bug: read it as declared intent for
 the pinned value, scoped to files whose role is verification.
+When such a claim's header shows gap type [uncategorized], also emit `gap_type`
+classifying which invariant the alleged bug violates: one stated in an artifact
+(comment, docstring, type, documentation) is a description gap; one that lives
+only in an implicit cross-component agreement (a shared literal, schema, or
+ABI) is a contract gap. Keep `uncategorized` when neither can be stated — that
+is the honest outlet, not a failure.
 
 """,
     "prose_doc_gaps": """\
@@ -690,6 +696,19 @@ def _reasoning_contradicts_verdict(verdict: str | None, reasoning: str | None) -
     return not _NEGATION_WORD.search(last[: m.start()])
 
 
+# LLM-assigned gap_type split (decisions/0025): only claims the mechanical
+# layer parked as ``uncategorized`` may be re-routed, and only to these values.
+_GAP_SPLIT_ALLOWED = frozenset({"description", "contract", "uncategorized"})
+
+
+def _split_gap_type(finding: Finding, assigned: Any) -> str:
+    """The gap_type to persist: LLM split applies only to parked claims."""
+
+    if finding.gap_type == "uncategorized" and assigned in _GAP_SPLIT_ALLOWED:
+        return assigned
+    return finding.gap_type
+
+
 def _apply_verdict(finding: Finding, v: dict) -> Finding:
     """Return a copy of ``finding`` with triage outputs from a verdict dict.
 
@@ -714,6 +733,7 @@ def _apply_verdict(finding: Finding, v: dict) -> Finding:
         suggested_fix=v.get("suggested_fix"),
         severity=v.get("severity"),
         contract_class=v.get("contract_class"),
+        gap_type=_split_gap_type(finding, v.get("gap_type")),
     )
 
 
@@ -728,6 +748,7 @@ def _apply_cached(finding: Finding, cached: dict) -> Finding:
         suggested_fix=cached.get("suggested_fix"),
         severity=cached.get("severity"),
         contract_class=cached.get("contract_class"),
+        gap_type=_split_gap_type(finding, cached.get("gap_type")),
     )
 
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -626,3 +626,78 @@ async def test_malformed_verdict_entries_do_not_crash_the_batch(config):
     result = await triage.decide_batch(claims, mode="claim")
     assert result.findings[0].verdict is None
     assert result.findings[1].verdict == "dismissed"
+
+
+# --- LLM-assigned gap_type split for parked claims (decisions/0025) ---------
+
+
+def test_gap_type_split_applied_to_uncategorized_claim():
+    f = _apply_verdict(make_finding(gap_type="uncategorized"), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.9,
+        "reasoning": "The docstring states the invariant the code violates. Confirming.",
+        "gap_type": "description",
+    })
+    assert f.gap_type == "description"
+
+
+def test_gap_type_split_contract_applied():
+    f = _apply_verdict(make_finding(gap_type="uncategorized"), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.85,
+        "reasoning": "Two sites share the literal; the agreement is implicit. Confirming.",
+        "gap_type": "contract",
+    })
+    assert f.gap_type == "contract"
+
+
+def test_gap_type_never_overrides_mechanical_assignment():
+    f = _apply_verdict(make_finding(gap_type="reachability"), {
+        "batch_index": 0,
+        "verdict": "confirmed",
+        "confidence": 0.9,
+        "reasoning": "No live path. Confirming.",
+        "gap_type": "description",
+    })
+    assert f.gap_type == "reachability"
+
+
+def test_gap_type_invalid_value_ignored():
+    f = _apply_verdict(make_finding(gap_type="uncategorized"), {
+        "batch_index": 0,
+        "verdict": "dismissed",
+        "confidence": 0.8,
+        "reasoning": "The guard already handles it. Dismissing.",
+        "gap_type": "bogus",
+    })
+    assert f.gap_type == "uncategorized"
+
+
+def test_gap_type_absent_leaves_parking():
+    f = _apply_verdict(make_finding(gap_type="uncategorized"), {
+        "batch_index": 0,
+        "verdict": "uncertain",
+        "confidence": 0.4,
+        "reasoning": "Cannot state the invariant class.",
+    })
+    assert f.gap_type == "uncategorized"
+
+
+def test_cached_gap_type_reapplied_with_same_guard():
+    from osoji.triage import _apply_cached
+
+    cached = {
+        "verdict": "confirmed",
+        "confidence": 0.9,
+        "triage_reasoning": "stated invariant",
+        "suggested_fix": None,
+        "severity": "warning",
+        "contract_class": None,
+        "gap_type": "description",
+    }
+    parked = _apply_cached(make_finding(gap_type="uncategorized"), cached)
+    assert parked.gap_type == "description"
+    mechanical = _apply_cached(make_finding(gap_type="contract"), cached)
+    assert mechanical.gap_type == "contract"

--- a/tests/test_triage_sectioning.py
+++ b/tests/test_triage_sectioning.py
@@ -18,9 +18,10 @@ from osoji.triage import (
 
 # sha256 of TRIAGE_SYSTEM_PROMPT. A deliberate rubric change must update this
 # hash in the same PR and carry its A/B evidence (wiki decisions/0022).
-# History: 16b45f61… at the work#66 sectioning refactor; current hash is the
-# work#78/work#79 change (confirmed-verdict semantics + latent_bug rigor).
-FROZEN_SHA = "67141f5531e49c51a33aba677b1b2966971935ca26d1165f0b6ffff7da9847e9"
+# History: 16b45f61… at the work#66 sectioning refactor; 67141f55… at the
+# work#78/work#79 change; current hash adds the decisions/0025 latent_bug
+# gap_type split instruction.
+FROZEN_SHA = "19190bee9f15342a6a99199b1e2f025510756a62e0d078149faf2ce933a20d94"
 
 
 def test_assembled_prompt_is_byte_identical() -> None:


### PR DESCRIPTION
## Mechanism

After #158, the gap_type `uncategorized` outlet holds exactly one population: latent_bug claims, parked because the stated-vs-implicit invariant split cannot be decided mechanically at propose time. Ruling (recorded in the project wiki, decisions/0025): the Triage LLM assigns the split per case — it already reads the invariant to judge Reality.

## Changes

- Optional `gap_type` verdict field (`description|contract|uncategorized`) on the triage verdict schema.
- Applied in `_apply_verdict`/`_apply_cached` ONLY when the claim's proposed gap_type is `uncategorized` — the LLM never overrides a mechanically-known gap type. Invalid/absent values leave the parking untouched.
- Verdict cache harvests `gap_type` so cached replays keep the split (same guard on re-apply).
- Rubric: the latent_bug section gains the split instruction (stated invariant → description; implicit cross-component agreement → contract; neither stateable → keep `uncategorized`, the honest outlet). Sectioning sha pin updated per policy.

## Evidence

Evaluator gate run `eval-20260722-5da89358` (68 cases, live): **all pinned thresholds hold** — tp 0.788, fp 0.185 (max 0.2; the closest approach across today's four passes, consistent with measured single-pass variance tp 0.667–0.788 on identical code), accuracy_nongray 0.700, undecided 0.0, ce_gap_gap_type 0.2206 (max 0.25), ce_gap_contract_other 0.0909 (max 0.10). Split behavior on the 15 parked latent_bug cases: 11 → description, 2 → contract, 2 honestly kept uncategorized.

## Tests

TDD: 6 new unit tests (application, both guards, invalid/absent values, cache path). Full suite 1471 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)