### PR TITLE
carry triage fields into observatory export bundle (osojicode/work#35, osojicode/work#76)

### DIFF
--- a/src/osoji/observatory.py
+++ b/src/osoji/observatory.py
@@ -21,7 +21,7 @@ from .scorecard import merge_ranges
 from .walker import discover_directories, discover_files
 
 OBSERVATORY_SCHEMA_NAME = "osoji-observatory"
-OBSERVATORY_SCHEMA_VERSION = "1.3.0"
+OBSERVATORY_SCHEMA_VERSION = "1.4.0"
 _DEFAULT_OUTPUT_NAME = "observatory.json"
 _SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 
@@ -138,6 +138,14 @@ def _load_audit_findings_by_path(config: Config) -> tuple[str, dict[str, list[di
             "remediation": issue.get("remediation"),
             "line_start": issue.get("line_start"),
             "line_end": issue.get("line_end"),
+            # Triage outputs ride alongside the heuristic `remediation`, never
+            # replacing it. Null when no decided Finding backs this issue
+            # (Triage never ran, or the seam degraded).
+            "finding_id": issue.get("finding_id"),
+            "verdict": issue.get("verdict"),
+            "confidence": issue.get("confidence"),
+            "triage_reasoning": issue.get("triage_reasoning"),
+            "suggested_fix": issue.get("suggested_fix"),
         }
         if "origin" in issue:
             finding["origin"] = issue["origin"]

--- a/src/osoji/osoji-observatory.schema.json
+++ b/src/osoji/osoji-observatory.schema.json
@@ -191,7 +191,12 @@
         "message",
         "remediation",
         "line_start",
-        "line_end"
+        "line_end",
+        "finding_id",
+        "verdict",
+        "confidence",
+        "triage_reasoning",
+        "suggested_fix"
       ],
       "properties": {
         "severity": { "type": "string" },
@@ -200,7 +205,27 @@
         "remediation": { "type": ["string", "null"] },
         "line_start": { "type": ["integer", "null"] },
         "line_end": { "type": ["integer", "null"] },
-        "origin": { "$ref": "#/$defs/Origin" }
+        "origin": { "$ref": "#/$defs/Origin" },
+        "finding_id": {
+          "description": "Triage output: id of the decided Finding backing this issue; null when Triage never ran or the seam degraded.",
+          "type": ["string", "null"]
+        },
+        "verdict": {
+          "description": "Triage output: the Triage verdict for this issue; null when no decided Finding backs it.",
+          "type": ["string", "null"]
+        },
+        "confidence": {
+          "description": "Triage output: confidence in the verdict (0.0-1.0); null when no decided Finding backs it.",
+          "type": ["number", "null"]
+        },
+        "triage_reasoning": {
+          "description": "Triage output: rationale for the verdict; null when no decided Finding backs it.",
+          "type": ["string", "null"]
+        },
+        "suggested_fix": {
+          "description": "Triage output: LLM-suggested fix riding alongside the heuristic remediation; null when no decided Finding backs it.",
+          "type": ["string", "null"]
+        }
       }
     },
     "FileShadow": {

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -381,12 +381,12 @@ def test_bundle_doc_analysis_empty_when_no_docs(temp_dir):
     assert bundle["doc_analysis"] == {}
 
 
-def test_bundle_schema_version_is_1_3_0(temp_dir):
+def test_bundle_schema_version_is_1_4_0(temp_dir):
     _write_source(temp_dir, "main.py", "x = 1\n")
 
     bundle = build_observatory_bundle(temp_dir, respect_gitignore=False)
 
-    assert bundle["schema_version"] == "1.3.0"
+    assert bundle["schema_version"] == "1.4.0"
 
 
 def test_export_command_writes_bundle_file(temp_dir):
@@ -555,6 +555,68 @@ def test_audit_finding_with_origin_passes_through(temp_dir):
     assert len(file_node["audit_findings"]) == 1
     finding = file_node["audit_findings"][0]
     assert finding["origin"] == {"source": "static", "plugin": "eslint"}
+
+    schema = _load_schema()
+    jsonschema.validate(instance=bundle, schema=schema)
+
+
+def test_bundle_audit_findings_carry_triage_fields(temp_dir):
+    _write_source(temp_dir, "main.py", "x = 1\n")
+    _write_audit_result(temp_dir, [
+        {
+            "path": "main.py",
+            "severity": "warning",
+            "category": "dead_code",
+            "message": "Unused var",
+            "remediation": "Remove it",
+            "line_start": 1,
+            "line_end": 1,
+            "finding_id": "f-123",
+            "verdict": "true_positive",
+            "confidence": 0.9,
+            "triage_reasoning": "No references anywhere",
+            "suggested_fix": "Delete line 1",
+        }
+    ])
+
+    bundle = build_observatory_bundle(temp_dir, respect_gitignore=False)
+
+    file_node = _find_file_node(bundle["tree"], "main.py")
+    finding = file_node["audit_findings"][0]
+    assert finding["finding_id"] == "f-123"
+    assert finding["verdict"] == "true_positive"
+    assert finding["confidence"] == 0.9
+    assert finding["triage_reasoning"] == "No references anywhere"
+    assert finding["suggested_fix"] == "Delete line 1"
+    # Triage signal rides alongside the heuristic remediation, never replaces it.
+    assert finding["remediation"] == "Remove it"
+
+    schema = _load_schema()
+    jsonschema.validate(instance=bundle, schema=schema)
+
+
+def test_bundle_audit_findings_triage_fields_null_when_absent(temp_dir):
+    # Findings that never reached Triage (e.g. degraded phases) carry null.
+    _write_source(temp_dir, "main.py", "x = 1\n")
+    _write_audit_result(temp_dir, [
+        {
+            "path": "main.py",
+            "severity": "warning",
+            "category": "dead_code",
+            "message": "Unused var",
+            "remediation": "Remove it",
+            "line_start": 1,
+            "line_end": 1,
+        }
+    ])
+
+    bundle = build_observatory_bundle(temp_dir, respect_gitignore=False)
+
+    file_node = _find_file_node(bundle["tree"], "main.py")
+    finding = file_node["audit_findings"][0]
+    for key in ("finding_id", "verdict", "confidence", "triage_reasoning", "suggested_fix"):
+        assert key in finding
+        assert finding[key] is None
 
     schema = _load_schema()
     jsonschema.validate(instance=bundle, schema=schema)


### PR DESCRIPTION
## Mechanism

`osoji export` builds the observatory bundle in `observatory.py`. Each file
node carries `audit_findings`, populated by `_load_audit_findings_by_path`,
which copies a fixed whitelist of keys out of `audit-result.json`'s `issues`.
PR #138 put five Triage outputs (`finding_id`, `verdict`, `confidence`,
`triage_reasoning`, `suggested_fix`) on the serialized audit issue at the
product boundary, but the whitelist never copied them — so the triage signal
was dropped before reaching the export bundle the dashboard consumes.

## Fix

- Extend the `_load_audit_findings_by_path` whitelist copy with the five
  Triage fields (`issue.get(...)`, so they carry `null` for findings that
  never reached Triage — e.g. degraded phases). The heuristic `remediation`
  stays a separate field; triage rides alongside it, never replaces it.
- Add the five fields (all nullable) to `$defs.AuditFinding` in
  `osoji-observatory.schema.json`, matching the always-emitted-and-nullable
  convention already used by `remediation` / `line_start` / `line_end`.
- Bump `OBSERVATORY_SCHEMA_VERSION` 1.3.0 -> 1.4.0 (1.3 was already consumed
  by the `degraded_phases` change).

The doc-analysis classification `confidence` field is a different, unrelated
value and is untouched. No runtime validation was added — schema validation
stays exclusively in `tests/test_observatory.py`. The osoji-teams ingest side
is coordinated by a separate work ticket and is not touched here.

## Tests

- `test_bundle_schema_version_is_1_4_0` — asserts the bumped version.
- `test_bundle_audit_findings_carry_triage_fields` — a bundle whose audit
  findings carry the five fields validates against the schema; heuristic
  `remediation` is preserved alongside.
- `test_bundle_audit_findings_triage_fields_null_when_absent` — findings with
  no triage inputs emit the five keys as `null` and validate.

Full suite: `PYTHONPATH=src python -m pytest -m "not prompt_regression and not live_smoke and not corpus_evaluate"` -> 1467 passed, 10 skipped, 11 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)