### PR TITLE
thread maintainer-declared project rules into triage user message (osojicode/work#35)

### DIFF
--- a/src/osoji/audit_manifest.py
+++ b/src/osoji/audit_manifest.py
@@ -18,6 +18,7 @@ under ``.osoji/analysis/``, which the audit wipes at the start of every run.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from collections.abc import Iterable
@@ -36,10 +37,22 @@ class IncrementalAuditError(RuntimeError):
     """Raised when an incremental-audit precondition fails (e.g. bad --since)."""
 
 
-def current_version() -> str:
-    """Return the osoji logic version stamp for manifest validation."""
+def current_version(project_rules: str | None = None) -> str:
+    """Return the osoji logic version stamp for manifest validation.
 
-    return f"{CLAIM_BUILDER_SCHEMA_VERSION}:{compute_impl_hash()}"
+    ``project_rules`` (maintainer-declared triage intent, work#35) folds into the
+    stamp so cached verdicts invalidate when the rules change: the rules ride in
+    the Triage user message, so a rules edit is a logic change for cache
+    purposes. Absent or blank rules leave the stamp byte-identical to the
+    pre-rules version — existing manifests stay valid (no invalidation for
+    users who declare none).
+    """
+
+    base = f"{CLAIM_BUILDER_SCHEMA_VERSION}:{compute_impl_hash()}"
+    if not (project_rules and project_rules.strip()):
+        return base
+    digest = hashlib.sha256(project_rules.encode("utf-8")).hexdigest()[:16]
+    return f"{base}:rules-{digest}"
 
 
 def get_head_commit(root: Path) -> str | None:

--- a/src/osoji/junk_triage.py
+++ b/src/osoji/junk_triage.py
@@ -60,12 +60,19 @@ async def decide_junk_claims(
     *,
     batch_size: int = BATCH_SIZE,
     system_prompt: str = TRIAGE_SYSTEM_PROMPT,
+    project_rules: str | None = None,
     on_progress: Callable[[int, int, Path, str], None] | None = None,
 ) -> tuple[list[Finding], int, int]:
     """Decide claims through Triage in bounded concurrent chunks.
 
     Returns ``(findings, input_tokens, output_tokens)`` with ``findings``
     aligned 1:1 with ``claims``.
+
+    ``project_rules`` (work#35) forwards maintainer-declared project rules to
+    every chunk's :meth:`Triage.decide_batch` call so they are weighed as
+    declared intent. Defaults to ``None``: the source wiring (where the rules
+    text is read from) is intentionally deferred, so today every production
+    caller uses the default.
     """
 
     if not claims:
@@ -107,6 +114,7 @@ async def decide_junk_claims(
                 chunk,
                 mode="claim",
                 system_prompt=system_prompt,
+                project_rules=project_rules,
                 verdict_cache=session.cache if session is not None else None,
             )
         except Exception as exc:

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -321,6 +321,29 @@ class TriageBatchResult:
 _MAX_EXPLORATION_TURNS = 8
 
 
+def _maintainer_intent_block(project_rules: str) -> str:
+    """Frame maintainer-declared project rules for the Triage user message.
+
+    The rules are the maintainers' own statement of intended design, weighed as
+    declared intent (decisions/0021 sense) — evidence to reason over, never a
+    catalog of per-case verdict instructions or a mechanical suppression list.
+    The framing is ours and deliberately short; the rules text rides through
+    verbatim as user content.
+    """
+
+    return (
+        "## Maintainer-declared project rules\n"
+        "The project maintainers have declared the rules below. Weigh them as "
+        "declared intent — the project's own statement of intended design — when "
+        "deciding a finding's Reality, not as per-case verdict instructions: they "
+        "are evidence to reason over, never a directive to confirm or dismiss any "
+        "particular claim.\n"
+        "--- begin maintainer-declared rules ---\n"
+        f"{project_rules}\n"
+        "--- end maintainer-declared rules ---\n\n"
+    )
+
+
 def _claim_echo(finding: Finding) -> str:
     """Identity token a batch verdict must echo back (cross-wiring guard).
 
@@ -362,6 +385,7 @@ class Triage:
         *,
         mode: str = "claim",
         system_prompt: str = TRIAGE_SYSTEM_PROMPT,
+        project_rules: str | None = None,
         verdict_cache: dict[tuple[str, str], dict] | None = None,
         escalate_insufficient: bool = False,
     ) -> TriageBatchResult:
@@ -376,6 +400,15 @@ class Triage:
         - ``insufficient_evidence`` claims escalate to exploration only when
           ``escalate_insufficient`` is True; otherwise they pass through
           unverified (verdict stays ``None``). The count is always reported.
+
+        ``project_rules`` (work#35): non-empty maintainer-declared project rules
+        are prepended, in a clearly-delimited block, to the USER message (before
+        the claims) so Triage can weigh them as declared intent. The SYSTEM
+        prompt is untouched — the sectioning sha pin and the ablation harness are
+        unaffected. Absent/blank rules leave the user message byte-identical to a
+        no-rules run. Because the rules ride in the user message, callers fold a
+        hash of the same text into ``audit_manifest.current_version()`` so cached
+        verdicts invalidate when the rules change.
         """
 
         n = len(claims)
@@ -409,7 +442,8 @@ class Triage:
             try:
                 if claim_route:
                     decided, ti, to = await self._run_claim_batch(
-                        [c for _, c in claim_route], system_prompt, provider
+                        [c for _, c in claim_route], system_prompt, provider,
+                        project_rules=project_rules,
                     )
                     for (idx, _), fnd in zip(claim_route, decided):
                         findings[idx] = fnd
@@ -417,7 +451,7 @@ class Triage:
                     out_tok += to
                 for idx, claim in explore_route:
                     fnd, ti, to, trace = await self._run_exploration(
-                        claim, system_prompt, provider
+                        claim, system_prompt, provider, project_rules=project_rules,
                     )
                     findings[idx] = fnd
                     in_tok += ti
@@ -459,10 +493,17 @@ class Triage:
     # -- claim mode --------------------------------------------------------
 
     async def _run_claim_batch(
-        self, claims: list[Claim], system_prompt: str, provider: Any
+        self,
+        claims: list[Claim],
+        system_prompt: str,
+        provider: Any,
+        *,
+        project_rules: str | None = None,
     ) -> tuple[list[Finding], int, int]:
         n = len(claims)
         user = self._render_claim_batch(claims)
+        if project_rules and project_rules.strip():
+            user = _maintainer_intent_block(project_rules) + user
 
         def check_completeness(tool_name: str, tool_input: dict) -> list[str]:
             if tool_name != "submit_triage_verdicts":
@@ -573,7 +614,12 @@ class Triage:
     # -- exploration mode (implemented in V1-3 task #5) --------------------
 
     async def _run_exploration(
-        self, claim: Claim, system_prompt: str, provider: Any
+        self,
+        claim: Claim,
+        system_prompt: str,
+        provider: Any,
+        *,
+        project_rules: str | None = None,
     ) -> tuple[Finding, int, int, dict[str, Any]]:
         """Decide one claim via a multi-turn read/grep/list loop.
 
@@ -593,6 +639,8 @@ class Triage:
             + "\nExplore the repository with read_file / grep / list_dir as needed, "
             "then call submit_triage_verdict with your decision."
         )
+        if project_rules and project_rules.strip():
+            user = _maintainer_intent_block(project_rules) + user
         messages: list[Message] = [Message(role=MessageRole.USER, content=user)]
         trace: dict[str, Any] = {"finding_id": finding.id, "calls": []}
         tools = get_triage_exploration_tool_definitions()

--- a/tests/test_audit_manifest.py
+++ b/tests/test_audit_manifest.py
@@ -68,6 +68,25 @@ def test_current_version_embeds_schema_and_impl_hash():
     assert len(version) > len(CLAIM_BUILDER_SCHEMA_VERSION) + 1
 
 
+def test_current_version_stable_without_project_rules():
+    # Existing users pass no rules; folding must not invalidate their manifests.
+    base = current_version()
+    assert current_version(None) == base
+    assert current_version("") == base
+    assert current_version("   \n\t ") == base
+
+
+def test_current_version_changes_with_project_rules():
+    # Maintainer-declared rules ride in the Triage user message (work#35), so a
+    # rules edit is a logic change for cache purposes: cached verdicts must
+    # invalidate.
+    assert current_version("Prefer deletion over commenting-out.") != current_version()
+
+
+def test_current_version_distinct_per_rules_text():
+    assert current_version("rule A") != current_version("rule B")
+
+
 # -- load / write round trip --------------------------------------------------
 
 

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -14,6 +14,7 @@ from osoji.evidence import Evidence
 from osoji.findings import Finding
 from osoji.llm.types import CompletionResult, ToolCall
 from osoji.triage import (
+    TRIAGE_SYSTEM_PROMPT,
     Claim,
     Triage,
     TriageBatchResult,
@@ -170,6 +171,71 @@ async def test_claim_mode_uses_supplied_system_prompt(config):
     triage = Triage(config, provider=provider)
     await triage.decide_batch([Claim(make_finding())], mode="claim", system_prompt="CUSTOM-RUBRIC")
     assert provider.calls[0]["system"] == "CUSTOM-RUBRIC"
+
+
+# --- maintainer-declared project rules -> triage user message (work#35) -----
+
+
+async def _claim_user_and_system(config, **decide_kwargs) -> tuple[str, str]:
+    """Run one claim-mode batch; return (user_message, system_prompt)."""
+    provider = FakeProvider([
+        verdicts_result([{"batch_index": 0, "verdict": "confirmed",
+                          "confidence": 1.0, "reasoning": "x"}])
+    ])
+    triage = Triage(config, provider=provider)
+    await triage.decide_batch([Claim(make_finding())], mode="claim", **decide_kwargs)
+    call = provider.calls[0]
+    return call["messages"][0].content, call["system"]
+
+
+@pytest.mark.asyncio
+async def test_project_rules_prepends_intent_block_before_claims(config):
+    rules = "Prefer deleting dead code over commenting it out."
+    with_rules, _ = await _claim_user_and_system(config, project_rules=rules)
+    baseline, _ = await _claim_user_and_system(config)
+
+    # The maintainer's rules ride through verbatim, inside a delimited block.
+    assert rules in with_rules
+    assert "maintainer-declared rules" in with_rules
+    # The block precedes the claims; the claims portion is byte-identical.
+    assert with_rules.index("maintainer-declared rules") < with_rules.index("## Claims to triage")
+    assert with_rules.endswith(baseline)
+
+
+@pytest.mark.asyncio
+async def test_absent_project_rules_leaves_user_message_byte_identical(config):
+    baseline, _ = await _claim_user_and_system(config)
+    with_none, _ = await _claim_user_and_system(config, project_rules=None)
+    with_empty, _ = await _claim_user_and_system(config, project_rules="")
+    with_blank, _ = await _claim_user_and_system(config, project_rules="   \n  ")
+
+    assert with_none == baseline
+    assert with_empty == baseline
+    assert with_blank == baseline
+
+
+@pytest.mark.asyncio
+async def test_project_rules_do_not_touch_system_prompt(config):
+    _, sys_without = await _claim_user_and_system(config)
+    _, sys_with = await _claim_user_and_system(
+        config, project_rules="Prefer deleting dead code over commenting it out."
+    )
+    assert sys_with == sys_without == TRIAGE_SYSTEM_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_project_rules_prepend_in_exploration_mode(explore_repo):
+    rules = "Prefer deleting dead code over commenting it out."
+    provider = FakeProvider([
+        tool_use_result("submit_triage_verdict",
+                        {"verdict": "confirmed", "confidence": 1.0, "reasoning": "dead"},
+                        call_id="v1"),
+    ])
+    triage = Triage(explore_repo, provider=provider)
+    await triage.decide_batch([Claim(make_finding())], mode="exploration", project_rules=rules)
+    user_msg = provider.calls[0]["messages"][0].content
+    assert rules in user_msg
+    assert "maintainer-declared rules" in user_msg
 
 
 # --- cross-wiring guard for symbol-less claims (work#57) --------------------


### PR DESCRIPTION
## Mechanism

Osoji has no way to feed a project's own declared rules into Triage. Maintainers
who state intent (e.g. "prefer deleting dead code over commenting it out") get no
credit for it at decide time — Triage weighs only the assembled evidence, and the
`decisions/0021` notion of declared intent has no seam to enter through for
project-level rules.

## Fix

- `Triage.decide_batch(..., project_rules: str | None = None)`: when non-empty,
  a clearly-delimited **maintainer-declared intent** block is prepended to the
  batch **user message** (before the claims). The framing is principle-level —
  the rules are weighed as declared intent, evidence to reason over, never a
  catalog of per-case verdict instructions or a mechanical suppression list. The
  rules text itself rides through verbatim as user content.
- The **system prompt is untouched.** The sectioning sha pin
  (`tests/test_triage_sectioning.py`) and the ablation harness are unaffected —
  that test file is not in this diff.
- **Cache correctness**: `audit_manifest.current_version()` folds a hash of the
  rules text into the manifest version stamp, so cached verdicts invalidate when
  the rules change. Absent or blank rules leave the stamp byte-identical to the
  pre-rules version — existing manifests stay valid, no invalidation for users
  who declare none.
- `decide_junk_claims` (the shared production wrapper every detector routes
  through) forwards the parameter to `decide_batch`. The prepend applies in both
  claim and exploration routes so a declared parameter is never silently ignored.

**Source wiring intentionally deferred.** The design source does not specify
where the rules text comes from (a config field / file), so this PR builds only
the seam: the parameter defaults to `None` and every production caller uses that
default today. The config surface is left unbuilt — no invented config format.

## Tests

- `decide_batch` with `project_rules`: user message contains the delimited block
  before the claims; the claims portion is byte-identical (`endswith` baseline).
- Absent/`None`/empty/whitespace-only rules leave the user message byte-identical
  to a no-rules run.
- System prompt identical with and without rules (equals `TRIAGE_SYSTEM_PROMPT`).
- Exploration mode also prepends the block.
- `current_version()` changes with rules text, stable (and byte-identical to the
  no-arg call) without; distinct per rules text.
- Full deterministic suite green: `pytest -m "not prompt_regression and not
  live_smoke"` -> 1478 passed, 10 skipped, 11 deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
