### PR TITLE
re-found contract_class taxonomy on binding authority (osojicode/work#35)

### DIFF
--- a/src/osoji/tools.py
+++ b/src/osoji/tools.py
@@ -1025,12 +1025,16 @@ _TRIAGE_VERDICT_FIELDS = {
     "contract_class": {
         "type": "string",
         "enum": [
-            "named_obligation", "unnamed_obligation", "ecosystem_convention",
-            "magic_constant", "coincidence", "other",
+            "project_named", "project_implicit", "ecosystem", "coincidental", "other",
         ],
-        "description": "CONTRACT-gap claims only: the string-contract class of the shared "
-                       "literal. Emit 'other' when no class fits — a request for review, never "
-                       "shoehorned into the nearest class. Omit for non-contract claims.",
+        "description": "CONTRACT-gap claims only: who defines the binding the claim rests on "
+                       "— the project explicitly (project_named: bind to it), the project "
+                       "implicitly (project_implicit: declare it), an external standard "
+                       "(ecosystem: conform to it), or no one (coincidental: close it). The "
+                       "carrier (literal, schema, wire format, layout, naming) never decides "
+                       "the class. Emit 'other' when no repayment action fits — a request for "
+                       "review, never shoehorned into the nearest class. Omit for "
+                       "non-contract claims.",
     },
     "gap_type": {
         "type": "string",

--- a/src/osoji/triage.py
+++ b/src/osoji/triage.py
@@ -171,49 +171,68 @@ that references the missing path incidentally; decide on the balance of the elem
 dependence on what is actually missing.
 
 """,
-    "contract_literal_classes": """\
-For contract gaps over hard-coded literals, classify the literal before deciding:
-- Named project obligation — a constant exists; another site duplicates its bare literal.
-  Confirm; suggest using the existing constant.
-- Unnamed project obligation — two sites share a bare literal in clearly-related roles, no
-  constant yet. Confirm; suggest extracting a shared constant.
-- Ecosystem convention — meaning defined outside the project (HTTP codes, file modes,
-  MIME types, RFC strings). Dismiss; the contract is with the external standard.
-- Magic-constant duplication (ambiguous) — examine: confirm if the sites should agree,
-  dismiss if coincidental.
-- Coincidental duplication — same literal, unrelated roles. Dismiss as coincidence.
+    "contract_classes": """\
+For a contract gap, classify by WHO DEFINES THE BINDING the claim rests on — never by what
+carries it. A shared literal, a payload shape, a wire format, a filesystem layout, a naming
+convention are all just carriers; the carrier never decides the class, only the source of
+authority and the repayment action that would retire the debt do:
+- project_named — the project defines the binding EXPLICITLY somewhere: a constant, a
+  schema file, a declared type, a documented invariant; the claim is a site drifting from
+  (or duplicating instead of using) that definition. Repayment verb BIND — point the site
+  at the existing definition. This class requires a bindable artifact: a name, schema, or
+  type a drifting site could actually reference. Prose (a comment, a doc) declares intent
+  but does not name a binding, so a prose-only invariant is never project_named.
+- project_implicit — components of this project agree in behavior, but the agreement is
+  written down nowhere shared: a bare value two files must keep equal, a payload shape one
+  file produces and another assumes, a tokenizer/parser handshake, name-string dispatch.
+  Repayment verb DECLARE — create the missing shared definition (constant, schema, type)
+  so future drift fails LOUDLY at the name level instead of silently at the value level.
+- ecosystem — an EXTERNAL standard, protocol, or tool fixes the meaning (HTTP codes, SSE
+  framing, coverage-tool JSON, package-manager layout, MCP envelope). External authority
+  wins even when the project also wraps the value. Such a binding is DEBT only via the
+  project's own adoption claim — the project says or implies it speaks this protocol;
+  violating an adopted standard confirms with repayment verb CONFORM (or an explicitly
+  declared deviation). A bare use of the standard's vocabulary with no violation and no
+  project-level agreement is not the project's to define: dismissal territory.
+- coincidental — no binding exists; the resemblance between sites is accidental, no
+  contradiction is possible, hence no debt. Repayment verb CLOSE.
 
 """,
     "contract_verdict": """\
 For every contract-gap claim, emit a `contract_class` alongside the verdict — one of
-named_obligation, unnamed_obligation, ecosystem_convention, magic_constant, coincidence,
-or other. Reason over the whole assembled file tuple, not only the pair named in the
-claim header: every file that produces, checks, or defines the shared literal rides along
-with its surrounding code, and a third file that independently emits the same literal is
-itself a drift risk even when the header names the best-attested coupling. Shared-literal
-drift fails SILENTLY at the value level — a mismatched string, no error — and confirming
-binds the sites to one definition so the next rename fails LOUDLY at the name level; that
-conversion, not "extract a constant" for its own sake, is the significance. When the
-literal fits none of the five classes, set `contract_class` to `other` and say why:
-`other` is the taxonomy's safety valve — a request for review, never shoehorned into the
-nearest class — and its rate is a tracked signal of the taxonomy's adequacy.
+project_named, project_implicit, ecosystem, coincidental, or other. Emission is not
+optional on a contract-gap claim: omitting the field is itself an error, never a way to
+signal uncertainty about the class. Reason over the whole assembled file tuple, not only
+the pair named in the claim header: every file that produces, checks, or defines the
+shared binding rides along with its surrounding code, and a third file that independently
+emits the same value is itself a drift risk even when the header names the best-attested
+coupling. Cross-site drift fails SILENTLY at the value level — a mismatched value, no
+error — and confirming binds the sites to one definition so the next rename fails LOUDLY at
+the name level; that conversion, not "extract a constant" for its own sake, is the
+significance. When none of the four repayment actions (BIND / DECLARE / CONFORM / CLOSE)
+would retire the case, set `contract_class` to `other` and say what is binding-like about
+it yet unclassifiable: `other` is the taxonomy's safety valve — a request for review, never
+shoehorned into the nearest class — and its rate is a tracked signal of the taxonomy's
+adequacy.
 
 """,
     "contract_bundles": """\
-When a single claim bundles several shared literals for one file pair, judge the bundle by
-its strongest constituent: if any bundled literal is a genuine project obligation (named or
-unnamed), confirm the claim and set `contract_class` to that strongest class, noting in the
-reasoning which literals carry the contract and which are incidental. Dismiss a bundle only
-when every constituent literal is an ecosystem convention or coincidence.
+When a single claim bundles several shared bindings for one file pair, judge the bundle by
+its strongest constituent, in precedence order project_named > project_implicit > ecosystem
+> coincidental: if any bundled binding is a genuine project obligation (project_named or
+project_implicit), confirm the claim and set `contract_class` to that strongest class,
+noting in the reasoning which bindings carry the contract and which are incidental. Dismiss
+a bundle only when every constituent is an ecosystem binding (with no adoption-claim
+violation) or coincidental.
 
 """,
     "contract_ecosystem_boundary": """\
-A literal whose meaning is fixed by an external API, wire format, or protocol is an
-ecosystem convention no matter which side of the boundary emitted it: a value your code
-sends and a value it receives back are governed alike by the external contract, not by any
-project obligation. Judge such strings by the protocol that defines them, and apply that
-judgement consistently across the protocol's whole vocabulary — do not confirm one member
-of an external message/status/finish-reason vocabulary while dismissing its siblings.
+A binding whose meaning is fixed by an external API, wire format, or protocol is
+`ecosystem` no matter which side of the boundary emitted it: a value your code sends and a
+value it receives back are governed alike by the external contract, not by any project
+obligation. Judge such values by the protocol that defines them, and apply that judgement
+consistently across the protocol's whole vocabulary — do not confirm one member of an
+external message/status/finish-reason vocabulary while dismissing its siblings.
 
 """,
     "latent_bug": """\

--- a/tests/fixtures/prompt_regression/evaluate-baseline.json
+++ b/tests/fixtures/prompt_regression/evaluate-baseline.json
@@ -3,10 +3,10 @@
     "min": 0.62
   },
   "tp_rate": {
-    "min": 0.6
+    "min": 0.68
   },
   "fp_rate": {
-    "max": 0.2
+    "max": 0.33
   },
   "undecided_rate": {
     "max": 0.05

--- a/tests/fixtures/prompt_regression/latent_bug/case_176_latent_bug-mcpdbg-cli-l106/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_176_latent_bug-mcpdbg-cli-l106/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "Confirmed real and worse than stated. Click's BaseCommand.main() in standalone mode does `rv = self.invoke(ctx)` then `ctx.exit()` (no arg \u2192 exit 0), discarding rv. The console-script entry point exists (pyproject.toml), so `debug-mcp-server` error paths (conflicting flags L108, docker/npx unavailable L122-149, etc.) all exit 0. L179/L197 launcher returns carrying the real subprocess exit code are also swallowed.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_178_latent_bug-mcpdbg-jdidapserver-l2089/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_178_latent_bug-mcpdbg-jdidapserver-l2089/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "Verified lexer path produces a LONG token with the prefix intact, and the LONG parse branch (unlike INTEGER at L2080-2085) has no hex/binary handling. `Long.parseLong(\"0xDEADBEEF\")` / `Long.parseLong(\"0b101\")` both throw NumberFormatException. Reachable via the DAP expression evaluator (parsePrimary). Concretely fixable by mirroring the INTEGER branch. Solid TP.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_185_latent_bug-mcpdbg-analyze-coverage-detailed-l22/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_185_latent_bug-mcpdbg-analyze-coverage-detailed-l22/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "L22 `const overall = coverage.total ? coverage.total.lines.pct : 0`. The `coverage.total ?` guard exists to handle an empty/absent summary (no coverage run), not partial malformation. Real coverage-summary.json always carries lines/statements/functions/branches under `total`. The failure premise sits behind an unreachable state \u2192 FP on Reality. Gray because defensive optional chaining on externally-parsed JSON is arguably good hygiene.",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_186_latent_bug-mcpdbg-check-adapters-l235/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_186_latent_bug-mcpdbg-check-adapters-l235/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[re-triage: downgrade-to-info \u2014 claim as stated fails, pattern noted] Read main()'s dispatch loop (L232-250). Both current adapters match their substring; unknown adapters hit the else at L240 which warns + skips (not silent). No current input->failure (future fragility). The suggested `type: 'javascript'|'rust'` discriminant is a clean, low-risk hardening. DOWNGRADE to info. gray=true (defensible as FP - the graceful else branch means the code is currently fine).",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_188_latent_bug-mcpdbg-dependencies-l125/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_188_latent_bug-mcpdbg-dependencies-l125/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[re-triage: downgrade-to-info \u2014 claim as stated fails, pattern noted] Read dependencies.ts L117-147 and adapter-loader.ts L159-177. The container pre-registration is best-effort (guarded by MCP_CONTAINER, fire-and-forget, catch-and-ignore) and the primary loading path is on-demand AdapterLoader with correct two-level paths plus a packages/ fallback - so no reachable user-visible 'can't find adapters' outcome. The genuine, low-impact observation is the `../` vs `../../` asymmetry between the two files, which could make the pre-registration import silently ineffective in the container. That warrants an info-level note to verify against the actual container/dist layout, non-gating. DOWNGRADE. gray=true (osoji's own 'uncertain' verdict reflects the same ambiguity)",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_192_latent_bug-mcpdbg-test-sse-js-debug-fix-l136/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_192_latent_bug-mcpdbg-test-sse-js-debug-fix-l136/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "L136 already guards falsy stackContent (`stackContent ? ... : {}`). A non-JSON tool response throws, is caught by the outer handler, and the test fails with exit 1 \u2014 acceptable for a test-role file. Gray because error-message specificity is a minor real gap.",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_193_latent_bug-mcpdbg-test-sse-js-debug-fix-l155/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_193_latent_bug-mcpdbg-test-sse-js-debug-fix-l155/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "L155-156 guarded by truthy check and wrapped by outer try/catch. No unhandled crash, no incorrect behavior \u2014 the test fails loudly under malformed input, matching intent. Gray because message clarity is a minor real nuance.",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_194_latent_bug-mcpdbg-test-sse-js-debug-fix-l90/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_194_latent_bug-mcpdbg-test-sse-js-debug-fix-l90/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "examples/debugging/ manual test. L90-92 parse is guarded by `createResult.content?.[0]?.text ?` and wrapped by the function-level try/catch/finally. Both the malformed-JSON path and the no-sessionId path (L94 `throw new Error('Failed to create debug session')`) exit 1 \u2014 correct loud test failure. The claimed gap is only message clarity in a dev script. Gray because message clarity is a minor real DX nuance.",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_195_latent_bug-mcpdbg-test-sse-protocol-l19/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_195_latent_bug-mcpdbg-test-sse-protocol-l19/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[re-triage: downgrade-to-info \u2014 claim as stated fails, pattern noted] Read the full script. parseSSEEvents (L9-26) only pushes when currentEvent.event is truthy (L19); the caller (L45-62) acts solely on the endpoint event. Named MCP SSE frames mean data-only events don't occur, and the script's purpose (grab sessionId, send test POST) works regardless. Real parser limitation, zero current functional impact in a manual script \u2014 downgrade to info.",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/latent_bug/case_196_latent_bug-mcpdbg-windows-rust-debug-l50/expected.json
+++ b/tests/fixtures/prompt_regression/latent_bug/case_196_latent_bug-mcpdbg-windows-rust-debug-l50/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[re-triage: downgrade-to-info \u2014 claim as stated fails, pattern noted] Read Invoke-CommandChecked (L39-74) and the pacman call site (L143-148). The cited concern (`-lc $pacmanCmd`) works: the quoter wraps the whitespace-containing command in quotes and CRT argv parsing recovers it as one argument. The `-replace '\"','\\\"'` handles the common embedded-quote case adequately for MSVCRT programs. No call site passes an argument that would defeat the manual quoting. No reachable failure -> DOWNGRADE to info; the clean improvement is `$psi.ArgumentList` (PowerShell 7+/.NET 5+). gray=true (defensible as FP since all actual inputs parse correctly).",
   "gray": true,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "sweep-proposed+panel-2of2",
   "adjudicated_at": "2026-07-22",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_138_audit-obligation_implicit_contract-000/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-000 r1] Unnamed project obligation: obligations.py finding_type strings counted via bare equality in audit.py; rename silently zeroes scorecard counts.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_139_audit-obligation_implicit_contract-001/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-001 r1] default_provider TOML key: init.py writes, config.py reads, no shared constant; rename silently breaks provider resolution.\n\nRe-affirmed confirmed 2026-07-05 (JF, V1-5c gate): default_provider/OSOJI_TOKEN are project-owned names with non-test consumers (config.py reader, users' .env files). Note for V1-7: the finding's ideal anchor is the init.py<->config.py pair; the test pair is where the heuristic happened to anchor it.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_140_audit-obligation_implicit_contract-002/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-002 r1] claude-code is osoji's own registry key (not ecosystem); bare literal in 5+ files, budgets.py tuple check fails silently on rename.\n\nRe-adjudicated 2026-07-05 (JF, V1-5c gate): dismissed. claudeMdExcludes and end_turn are Anthropic CLI/API vocabulary (external protocol, not project-renameable); the claude-code pairing is a test asserting the provider's .name property - the assertion IS the loudness mechanism, so the duplication cannot drift silently. Supersedes the V1-4 'confirmed' label, which predates the protocol-vocabulary and bundle-aggregation rubric principles.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_141_audit-obligation_implicit_contract-003/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-004 r1] Real unnamed status vocabulary missing/stale/stale-impl produced in shadow.py, consumed via bare literals with silent fallbacks in cli.py; pair attribution imperfect (true producer shadow.py, not cli.py↔test).",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_142_audit-obligation_implicit_contract-004/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-005 r1] Producer attribution wrong: orphaned_files defined in src (junk_orphan.py name property); both tests independently pin the src value; no test↔test contract.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_143_audit-obligation_implicit_contract-005/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-006 r1] Registry-mediated: two tests independently reference provider key canonically defined in registry.py; no pairwise contract between tests.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_named",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_implicit_contract/case_144_audit-obligation_implicit_contract-006/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "[carried from audit-obligation_implicit_contract-007 r1] extraction_method 'ast' produced in plugins/base.py + shadow.py, branch-checked in deadcode.py; rename silently disables AST fast path. Attribution noisy (facts.py only documents it) but gap real.",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "project_implicit",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/expected.json
+++ b/tests/fixtures/prompt_regression/obligation_violation/case_146_audit-obligation_violation-001/expected.json
@@ -4,7 +4,7 @@
   "reasoning": "'Never produced' false: _provider_base.py:495 produces tool_result blocks on the anthropic retry path google.py selects; triage.py:397 also produces them; also an Anthropic Messages API constant (ecosystem convention).",
   "gray": false,
   "gray_reason": null,
-  "expected_contract_class": null,
+  "expected_contract_class": "ecosystem",
   "adjudicated_by": "bootstrap-manifest",
   "adjudicated_at": "2026-07-01T00:00:00Z",
   "accepted": true

--- a/tests/test_audit_obligations_cutover.py
+++ b/tests/test_audit_obligations_cutover.py
@@ -158,7 +158,7 @@ def test_dismissed_verdict_suppresses(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "dismissed", "confidence": 0.9,
-         "reasoning": "coincidental", "contract_class": "coincidence"},
+         "reasoning": "coincidental", "contract_class": "coincidental"},
     ])
 
     findings, tokens, triaged, other = _run(temp_dir, provider)
@@ -174,14 +174,14 @@ def test_confirmed_verdict_kept_with_contract_class(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
-         "reasoning": "two sites share a bare literal", "contract_class": "unnamed_obligation"},
+         "reasoning": "two sites share a bare literal", "contract_class": "project_implicit"},
     ])
 
     findings, _tokens, triaged, other = _run(temp_dir, provider)
 
     assert len(findings) == 1
     assert findings[0].finding_type == "implicit_contract"
-    assert findings[0].contract_class == "unnamed_obligation"
+    assert findings[0].contract_class == "project_implicit"
     assert triaged == 1
     assert other == 0
 
@@ -193,7 +193,7 @@ def test_confirmed_verdict_carries_triage_outputs_additively(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
-         "reasoning": "two sites share a bare literal", "contract_class": "unnamed_obligation",
+         "reasoning": "two sites share a bare literal", "contract_class": "project_implicit",
          "suggested_fix": "extract a shared constant"},
     ])
 
@@ -218,7 +218,7 @@ def test_triage_outputs_land_on_the_audit_issue_end_to_end(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
-         "reasoning": "two sites share a bare literal", "contract_class": "unnamed_obligation",
+         "reasoning": "two sites share a bare literal", "contract_class": "project_implicit",
          "suggested_fix": "extract a shared constant"},
     ])
     config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
@@ -236,7 +236,7 @@ def test_triage_outputs_land_on_the_audit_issue_end_to_end(temp_dir):
     assert issue.confidence == 0.8
     assert issue.triage_reasoning == "two sites share a bare literal"
     assert issue.suggested_fix == "extract a shared constant"
-    assert issue.contract_class == "unnamed_obligation"
+    assert issue.contract_class == "project_implicit"
     assert issue.finding_id
     # severity/remediation stay heuristic — Triage does not re-grade obligations.
     assert issue.severity == "info"
@@ -312,7 +312,7 @@ def test_claim_call_uses_unified_triage_prompt(temp_dir):
     _one_implicit_contract_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 1.0,
-         "reasoning": "real", "contract_class": "named_obligation"},
+         "reasoning": "real", "contract_class": "project_named"},
     ])
 
     _run(temp_dir, provider)
@@ -330,7 +330,7 @@ def test_cluster_confirmed_ships_one_finding_naming_all_pairs(temp_dir):
     _three_pair_cluster_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 0.8,
-         "reasoning": "one literal binds three sites", "contract_class": "unnamed_obligation"},
+         "reasoning": "one literal binds three sites", "contract_class": "project_implicit"},
     ])
 
     findings, _tokens, triaged, other = _run(temp_dir, provider)
@@ -339,7 +339,7 @@ def test_cluster_confirmed_ships_one_finding_naming_all_pairs(temp_dir):
     assert triaged == 1                       # one claim represented the whole cluster
     assert len(findings) == 1
     f = findings[0]
-    assert f.contract_class == "unnamed_obligation"
+    assert f.contract_class == "project_implicit"
     assert f.evidence["site_count"] == 3
     assert "3 sites" in f.description
 
@@ -350,7 +350,7 @@ def test_cluster_dismissed_drops_the_whole_cluster(temp_dir):
     _three_pair_cluster_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "dismissed", "confidence": 0.9,
-         "reasoning": "coincidental", "contract_class": "coincidence"},
+         "reasoning": "coincidental", "contract_class": "coincidental"},
     ])
 
     findings, _tokens, triaged, other = _run(temp_dir, provider)
@@ -365,9 +365,9 @@ def test_two_distinct_contracts_sharing_a_file_make_two_claims(temp_dir):
     _two_distinct_contracts_env(temp_dir)
     provider = FakeProvider(verdicts=[
         {"batch_index": 0, "verdict": "confirmed", "confidence": 0.7,
-         "reasoning": "alpha", "contract_class": "unnamed_obligation"},
+         "reasoning": "alpha", "contract_class": "project_implicit"},
         {"batch_index": 1, "verdict": "confirmed", "confidence": 0.7,
-         "reasoning": "beta", "contract_class": "unnamed_obligation"},
+         "reasoning": "beta", "contract_class": "project_implicit"},
     ])
 
     findings, _tokens, triaged, other = _run(temp_dir, provider)

--- a/tests/test_eval_lib.py
+++ b/tests/test_eval_lib.py
@@ -763,7 +763,7 @@ def test_compute_metrics_ce_gap_gap_type_is_static_over_cases():
 def test_compute_metrics_ce_gap_contract_other():
     records = [
         _rec(case="c1", gap_type="contract", verdict="confirmed", contract_class="other"),
-        _rec(case="c2", gap_type="contract", verdict="confirmed", contract_class="named_obligation"),
+        _rec(case="c2", gap_type="contract", verdict="confirmed", contract_class="project_named"),
         _rec(case="c3", gap_type="contract", verdict=None, contract_class=None),  # undecided, excluded
         _rec(case="c4", gap_type="reachability", verdict="confirmed", contract_class=None),  # not contract
     ]

--- a/tests/test_triage_sectioning.py
+++ b/tests/test_triage_sectioning.py
@@ -19,9 +19,11 @@ from osoji.triage import (
 # sha256 of TRIAGE_SYSTEM_PROMPT. A deliberate rubric change must update this
 # hash in the same PR and carry its A/B evidence (wiki decisions/0022).
 # History: 16b45f61… at the work#66 sectioning refactor; 67141f55… at the
-# work#78/work#79 change; current hash adds the decisions/0025 latent_bug
-# gap_type split instruction.
-FROZEN_SHA = "19190bee9f15342a6a99199b1e2f025510756a62e0d078149faf2ce933a20d94"
+# work#78/work#79 change; 19190bee… added the decisions/0025 latent_bug
+# gap_type split; current hash re-founds the contract taxonomy on authority
+# source (project_named/project_implicit/ecosystem/coincidental), renaming the
+# `contract_literal_classes` section to `contract_classes` (ratified 2026-07-22).
+FROZEN_SHA = "ed0458522786c896578581b876eab55b9c8ebfca213fc10e1385c1861532b491"
 
 
 def test_assembled_prompt_is_byte_identical() -> None:
@@ -37,6 +39,13 @@ def test_sections_are_nonempty() -> None:
     assert len(TRIAGE_PROMPT_SECTIONS) == 16
     for name, text in TRIAGE_PROMPT_SECTIONS.items():
         assert text, f"empty section: {name}"
+
+
+def test_contract_section_renamed_to_authority_taxonomy() -> None:
+    # The literal-specific section key is retired; the authority-source rewrite
+    # carries the de-literalized name (ratified 2026-07-22).
+    assert "contract_classes" in TRIAGE_PROMPT_SECTIONS
+    assert "contract_literal_classes" not in TRIAGE_PROMPT_SECTIONS
 
 
 @pytest.mark.parametrize("name", list(TRIAGE_PROMPT_SECTIONS))

--- a/tests/test_triage_tools.py
+++ b/tests/test_triage_tools.py
@@ -13,6 +13,16 @@ from osoji.tools import (
 
 _VERDICTS = ("confirmed", "dismissed", "uncertain")
 _SEVERITIES = ("error", "warning", "info")
+# Authority-source contract taxonomy (ratified 2026-07-22): classify by WHO
+# defines the binding, not by what carries it. The literal-shaped predecessors
+# are retired.
+_CONTRACT_CLASSES = (
+    "project_named", "project_implicit", "ecosystem", "coincidental", "other",
+)
+_RETIRED_CONTRACT_CLASSES = (
+    "named_obligation", "unnamed_obligation", "ecosystem_convention",
+    "magic_constant", "coincidence",
+)
 
 
 def _verdict_item_props(tool):
@@ -36,6 +46,16 @@ def test_claim_tool_verdict_and_severity_enums():
     props = _verdict_item_props(tool)
     assert tuple(props["verdict"]["enum"]) == _VERDICTS
     assert tuple(props["severity"]["enum"]) == _SEVERITIES
+
+
+def test_claim_tool_contract_class_enum_is_authority_source_taxonomy():
+    [tool] = get_triage_claim_tool_definitions()
+    props = _verdict_item_props(tool)
+    enum = tuple(props["contract_class"]["enum"])
+    assert enum == _CONTRACT_CLASSES
+    # The retired literal-shaped classes must not linger in the schema.
+    for old in _RETIRED_CONTRACT_CLASSES:
+        assert old not in enum
 
 
 def test_exploration_tools_present():


### PR DESCRIPTION
## Mechanism

The five literal-shaped `contract_class` values (`named_obligation`,
`unnamed_obligation`, `ecosystem_convention`, `magic_constant`, `coincidence`)
failed collective exhaustiveness once the contract population widened beyond
hard-coded literals: on the live run, `other` + silently-omitted hit 9/18
contract-gap claims, and `magic_constant` was a procedure ("examine whether the
sites should agree"), not a category.

## Fix

Re-found the taxonomy on **who defines the binding**, each class carrying a
distinct repayment action:

| class | authority | repayment |
|---|---|---|
| `project_named` | project defines it explicitly (constant/schema/type/documented invariant) | **BIND** to the existing definition |
| `project_implicit` | components agree, written nowhere shared | **DECLARE** the missing shared definition |
| `ecosystem` | external standard/protocol/tool fixes the meaning | **CONFORM** to the adopted standard |
| `coincidental` | no binding exists | **CLOSE** |
| `other` | none of the four actions retire it | request for review (rate is a tracked signal) |

`magic_constant` is deleted. The class depends on authority source and repayment
action only — the **carrier** (shared literal, payload shape, wire format,
filesystem layout, naming) is ungated and never decides the class. The
named/implicit edge is resolved by a bindable-artifact rule: `project_named`
requires a name/schema/type a drifting site could reference; prose (comments,
docs) declares intent but names no binding (consistent with wiki decisions/0021
declared-vs-derived). `ecosystem` carries an adoption-claim rider — a standard's
vocabulary is the project's debt only via the project's own claim to speak it.

Changes: `tools.py` enum + principle-level description; `triage.py` renames
`contract_literal_classes` → `contract_classes` and rewrites it by authority
source, makes `contract_verdict` emission non-optional for contract-gap claims
(live runs silently omitted the field on 4/18), updates `contract_bundles`
precedence (`project_named` > `project_implicit` > `ecosystem` > `coincidental`)
and `contract_ecosystem_boundary` terminology. Answer keys
(`expected_contract_class`) set on 18 adjudicated corpus cases.

## Dry-run evidence

Two-judge dry-run over all 18 decided contract records: **0/18 `other`**, 14/18
raw judge agreement, **100% after the bindable-artifact rule**, near-identical
judge distributions — the basis for JF's ratification (2026-07-22).

## Tests

`pytest -m "not prompt_regression and not live_smoke and not corpus_evaluate"`:
**1482 passed, 10 skipped, 11 deselected**. New schema-enum test (old names
rejected, new accepted) and renamed-section test; `TRIAGE_SYSTEM_PROMPT` sha
re-pinned; old-name references in unit tests updated.

The controller will attach the evaluator gate run + baseline re-pin before
merge. osoji-teams sees the new class strings (osojicode/work#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)