### PR TITLE
route all debris categories through unified Triage; retire legacy admission gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `[audit] exclude` in `.osoji.toml` — repo-relative glob patterns that
   remove matching paths from repository discovery entirely, scoping
   expensive analysis away from low-value trees (e.g. `docs/archive/**`)
+- Untriaged-debris floor: kept debris findings without a Triage verdict are
+  tagged `[untriaged]` in the report and counted on the scorecard
+  (`debris_untriaged`; observatory schema 1.5.0)
 
 ### Changed
+
+- All debris finding categories now route through unified Triage
+  (`stale_comment` unconditionally, plus `misleading_docstring`,
+  `commented_out_code`, `expired_todo`) — the legacy eligibility gate and
+  `DEBRIS_SCHEMA` sufficiency overrides are retired; Claim Builder schema
+  version cb-4 (invalidates the incremental verdict cache once)
 
 - LLM providers migrated from LiteLLM to direct SDKs (`anthropic`, `openai`,
   `google-genai`, OpenRouter via the OpenAI SDK); the 0.2.0 "all via LiteLLM"

--- a/scripts/measure_debris_cutover.py
+++ b/scripts/measure_debris_cutover.py
@@ -23,7 +23,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT / "src"))
 
-from osoji.claim_builder import _is_eligible, build_debris_claims  # noqa: E402
+from osoji.claim_builder import build_debris_claims  # noqa: E402
 from osoji.config import Config  # noqa: E402
 from osoji.evidence_builders import (  # noqa: E402
     _extract_all_symbols_from_debris,
@@ -59,6 +59,18 @@ def load_debris_ignoring_impl_hash(config: Config) -> list[dict]:
         except (json.JSONDecodeError, KeyError):
             continue
     return raw_debris
+
+
+def legacy_is_eligible(finding: dict) -> bool:
+    """The V1-3 eligibility gate, replicated verbatim (retired from production
+    by osoji#168 — this script measures against the frozen legacy behavior)."""
+
+    category = finding.get("category", "")
+    if category in ("dead_code", "latent_bug"):
+        return True
+    if category == "stale_comment" and finding.get("cross_file_verification_needed"):
+        return True
+    return False
 
 
 def legacy_claim_exists(config: Config, finding: dict, facts_db, symbols_by_file) -> bool:
@@ -102,7 +114,7 @@ def main() -> int:
 
     config = Config(root_path=REPO_ROOT)
     raw_debris = load_debris_ignoring_impl_hash(config)
-    eligible = [f for f in raw_debris if _is_eligible(f)]
+    eligible = [f for f in raw_debris if legacy_is_eligible(f)]
 
     facts_db = FactsDB(config)
     symbols_by_file = load_all_symbols(config)

--- a/src/osoji/audit.py
+++ b/src/osoji/audit.py
@@ -37,7 +37,6 @@ from .walker import _matches_ignore
 from .claim_builder import (  # noqa: F401  (re-exported helpers)
     _extract_all_symbols_from_debris,
     _infer_variable_type,
-    _is_eligible,
     _lookup_type_definitions,
     build_debris_claims,
 )
@@ -623,6 +622,7 @@ async def run_audit_async(
         })
 
     # Collect issues from Phase 3 (debris)
+    debris_untriaged = 0
     for i, finding in enumerate(raw_debris):
         if i in suppressed_indices:
             continue
@@ -632,6 +632,11 @@ async def run_audit_async(
         # finding to a lower severity, never drop it outright) — the heuristic
         # severity/remediation stay the fallback, never dropped.
         decided = debris_decided.get(i)
+        if decided is None or decided.verdict is None:
+            # Kept without a Triage verdict (unclaimable, evidence gate unmet,
+            # or a failed decide chunk) — counted for the scorecard and tagged
+            # [untriaged] in the report (osoji#168 interim floor).
+            debris_untriaged += 1
         heuristic_severity = finding["severity"]
         issues.append(AuditIssue(
             path=finding["source_path"],
@@ -712,6 +717,10 @@ async def run_audit_async(
     if obligations and not skip_obligations:
         scorecard.contract_claims_triaged = contract_triaged
         scorecard.contract_claims_other = contract_other
+    # Untriaged-debris floor (osoji#168): None when the phase didn't run — an
+    # excluded phase must not read as a clean bill of health.
+    if not skip_debris:
+        scorecard.debris_untriaged = debris_untriaged
     # V1-9: cache effectiveness across every Triage seam this run
     scorecard.verdict_cache_hit_rate = session.hit_rate
     if use_cache and session.claims_seen:
@@ -911,12 +920,13 @@ async def _run_phase2_async(config, rate_limiter, progress_cb, verbose):
 
 
 async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
-    """Phase 3: Triage debris findings against cross-file evidence.
+    """Phase 3: Triage debris findings against gathered evidence.
 
-    Builds self-sufficient claims for the eligible debris subset (the same subset
-    the legacy verify step gated on) and decides them through the shared chunked
-    decide loop (work#57: the V1-5e A/B saw a whole-corpus single call go
-    off-by-one from ~index 5; bounded chunks match every Phase 4 analyzer). A
+    Builds self-sufficient claims for every debris finding (osoji#168 retired
+    the legacy eligibility gate; findings whose evidence gate is unmet pass
+    through unverified) and decides them through the shared chunked decide
+    loop (work#57: the V1-5e A/B saw a whole-corpus single call go off-by-one
+    from ~index 5; bounded chunks match every Phase 4 analyzer). A
     ``dismissed`` verdict suppresses the finding — preserving the prior behavior
     where a confirmed-false-positive was dropped. Best-effort: on any failure
     all findings are kept.
@@ -933,8 +943,7 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
     suppressed_indices: set[int] = set()
     decided_by_index: dict[int, Finding] = {}
     phase_tokens = (0, 0)
-    needs_verification = any(_is_eligible(f) for f in raw_debris)
-    if needs_verification:
+    if raw_debris:
         try:
             claims, original_indices, would_escalate = build_debris_claims(config, raw_debris)
             if claims:
@@ -954,14 +963,14 @@ async def _run_phase3_async(config, raw_debris, rate_limiter, verbose):
                 phase_tokens = (in_tok, out_tok)
             if suppressed_indices and verbose:
                 _emit(config, f"  Dismissed {len(suppressed_indices)} false positive debris finding(s)")
-            # Dormant escalation tally (decision 0014): eligible findings whose
+            # Dormant escalation tally (decision 0014): findings whose
             # require_any gate was unmet are kept unverified, not escalated.
             # The rate is a V1-4 falsifiability metric — a climbing rate says
             # the Claim Builder schema needs revision.
             if would_escalate and verbose:
-                eligible_total = len(claims) + would_escalate
-                rate = would_escalate / eligible_total if eligible_total else 0.0
-                _emit(config, f"  {would_escalate} eligible finding(s) lacked gatherable evidence "
+                total = len(claims) + would_escalate
+                rate = would_escalate / total if total else 0.0
+                _emit(config, f"  {would_escalate} finding(s) lacked gatherable evidence "
                               f"(would-escalate; kept unverified; escalation rate {rate:.1%})")
             # #160: decide_junk_claims absorbs a permanent error to keep findings
             # (it never raises here), so attribute a tripped breaker to this phase.
@@ -1221,6 +1230,7 @@ def load_audit_result(config: Config) -> AuditResult:
             obligation_implicit_contracts=sc.get("obligation_implicit_contracts"),
             contract_claims_triaged=sc.get("contract_claims_triaged"),
             contract_claims_other=sc.get("contract_claims_other"),
+            debris_untriaged=sc.get("debris_untriaged"),
             verdict_cache_hit_rate=sc.get("verdict_cache_hit_rate"),
             concept_total=sc.get("concept_total"),
             concept_fully_documented=sc.get("concept_fully_documented"),
@@ -1272,6 +1282,8 @@ def _format_scorecard_section(scorecard: Scorecard) -> list[str]:
         rate = other / scorecard.contract_claims_triaged
         summary_rows.append(["Contract taxonomy", f"{other}/{scorecard.contract_claims_triaged} 'other' "
                              f"({rate:.0%} CE-gap rate)"])
+    if scorecard.debris_untriaged is not None:
+        summary_rows.append(["Untriaged debris", str(scorecard.debris_untriaged)])
     degradation_value = ", ".join(scorecard.degraded_phases) if scorecard.degraded_phases else "none"
     summary_rows.append(["Triage degradation", degradation_value])
     lines.append(_table(["Metric", "Value"], summary_rows))
@@ -1403,6 +1415,16 @@ These are informational only. No action is required. If you choose to act:
 Findings below are observations, not verdicts."""
 
 
+def _untriaged_tag(issue: AuditIssue) -> str:
+    """`` [untriaged]`` for a kept debris finding without a Triage verdict.
+
+    Debris-only: the other phases' verdict-``None`` issues were never Triage
+    candidates, so the tag would be noise there (osoji#168 interim floor)."""
+    if issue.exclude_key == "debris" and issue.verdict is None:
+        return " [untriaged]"
+    return ""
+
+
 def format_audit_report(result: AuditResult) -> str:
     """Format audit result as agent-ready markdown report."""
     if result.passed and not result.has_warnings and result.scorecard is None:
@@ -1446,7 +1468,7 @@ def format_audit_report(result: AuditResult) -> str:
         lines.append("## Errors (blocking)\n")
         for issue in errors:
             phase_tag = f" [phase: {issue.exclude_key}]" if issue.exclude_key else ""
-            lines.append(f"### `{issue.path}`{phase_tag}")
+            lines.append(f"### `{issue.path}`{phase_tag}{_untriaged_tag(issue)}")
             lines.append(f"**Category**: {issue.category}")
             lines.append(f"**Issue**: {issue.message}")
             lines.append(f"**Remediation**: {issue.remediation}")
@@ -1464,7 +1486,7 @@ def format_audit_report(result: AuditResult) -> str:
         lines.append("## Warnings (non-blocking)\n")
         for issue in warnings:
             phase_tag = f" [phase: {issue.exclude_key}]" if issue.exclude_key else ""
-            lines.append(f"- `{issue.path}`: {issue.message}{phase_tag}")
+            lines.append(f"- `{issue.path}`: {issue.message}{phase_tag}{_untriaged_tag(issue)}")
         lines.append("")
 
     infos = [i for i in result.issues if i.severity == "info"]

--- a/src/osoji/claim_builder.py
+++ b/src/osoji/claim_builder.py
@@ -17,10 +17,12 @@ this schema invalidates the whole cache (see osojicode/wiki
 and an empty-bundle fingerprint would let two distinct findings share a cached
 verdict (decision 0014).
 
-``build_debris_claims`` remains the audit Phase-3 entry point with its V1-3
-contract intact; it now runs on the generalized builders with the legacy
-sufficiency semantics (refs OR type definitions) encoded as ``require_any``
-overrides in :data:`DEBRIS_SCHEMA`.
+``build_debris_claims`` remains the audit Phase-3 entry point. Since osoji#168
+it admits every debris category on the general schema table — the V1-3
+eligibility gate and its legacy sufficiency overrides are retired; what
+survives of decision 0014 is the kept-unverified pass-through for findings
+whose ``require_any`` gate is unmet (tallied as ``would_escalate``, never
+escalated here).
 """
 
 from __future__ import annotations
@@ -45,7 +47,7 @@ from .triage import Claim
 #: Version tag of the Claim Builder schema (kind set + tables below). Part of
 #: every evidence_fingerprint; bump on any schema change so the V1-9 verdict
 #: cache invalidates rather than serving verdicts produced by an older schema.
-CLAIM_BUILDER_SCHEMA_VERSION = "cb-3"
+CLAIM_BUILDER_SCHEMA_VERSION = "cb-4"
 
 
 @dataclass(frozen=True)
@@ -111,6 +113,8 @@ CLAIM_BUILDER_SCHEMA: dict[str, SchemaEntry] = {
     # actually emits", not a uniform prefix convention.
     "stale_comment": _DESCRIPTION_ENTRY,
     "misleading_docstring": _DESCRIPTION_ENTRY,
+    "commented_out_code": _DESCRIPTION_ENTRY,
+    "expired_todo": _DESCRIPTION_ENTRY,
     "incorrect_content": _DESCRIPTION_ENTRY,
     "misleading_claim": _DESCRIPTION_ENTRY,
     "stale_content": _DESCRIPTION_ENTRY,
@@ -129,18 +133,6 @@ DEFAULT_SCHEMA_BY_GAP_TYPE: dict[str, SchemaEntry] = {
         require_any=frozenset({"surrounding_code", "cross_file_reference"}),
     ),
 }
-
-#: Debris cutover schema: the ratified kind lists with the LEGACY sufficiency
-#: gate (a claim existed iff cross-file refs OR type definitions were
-#: gatherable) so the V1-3 would_escalate semantics carry over unchanged.
-DEBRIS_SCHEMA: dict[str, SchemaEntry] = {
-    "dead_code": _REACHABILITY_ENTRY,
-    "stale_comment": replace(
-        _DESCRIPTION_ENTRY, require_any=frozenset({"cross_file_reference"})
-    ),
-    "latent_bug": _LATENT_BUG_ENTRY,
-}
-
 
 def category_of(finding: Finding) -> str:
     """The native category: the part of ``detector`` after ``<producer>:``."""
@@ -216,18 +208,7 @@ def build_claims(
     return claims
 
 
-# --- debris wrapper (V1-3 contract preserved) --------------------------------
-
-
-def _is_eligible(finding: dict) -> bool:
-    """Same eligibility gate as the legacy debris verify step."""
-
-    category = finding.get("category", "")
-    if category in ("dead_code", "latent_bug"):
-        return True
-    if category == "stale_comment" and finding.get("cross_file_verification_needed"):
-        return True
-    return False
+# --- debris wrapper ----------------------------------------------------------
 
 
 def build_debris_claims(
@@ -239,12 +220,16 @@ def build_debris_claims(
 ) -> tuple[list[Claim], list[int], int]:
     """Assemble debris Claims through the mechanized builders.
 
+    Every debris category is admitted (osoji#168 retired the V1-3 eligibility
+    gate and its DEBRIS_SCHEMA sufficiency overrides — migration-era detail,
+    not part of decision 0014's ruling).
+
     Returns ``(claims, original_indices, would_escalate)`` where
     ``original_indices[k]`` is the index into ``raw_debris`` of ``claims[k]`` —
     the unambiguous join used to map dismissed verdicts back to suppressions.
-    ``would_escalate`` counts eligible findings whose ``require_any`` gate was
-    unmet (the builders could not gather deciding evidence); they pass through
-    unverified, never escalated here (decision 0014).
+    ``would_escalate`` counts findings whose ``require_any`` gate was unmet
+    (the builders could not gather deciding evidence) or that carry no source
+    at all; they pass through unverified, never escalated here (decision 0014).
     """
 
     ctx = BuildContext(config, facts_db=facts_db, symbols_by_file=symbols_by_file)
@@ -254,13 +239,11 @@ def build_debris_claims(
     would_escalate = 0
 
     for i, finding in enumerate(raw_debris):
-        if not _is_eligible(finding):
-            continue
         if not (finding.get("source") or finding.get("source_path")):
             would_escalate += 1
             continue
         finding_obj = finding_from_debris(finding, root=config.root_path)
-        claim = build_claims([finding_obj], ctx, schema=DEBRIS_SCHEMA)[0]
+        claim = build_claims([finding_obj], ctx)[0]
         if claim.insufficient_evidence:
             would_escalate += 1
         else:

--- a/src/osoji/observatory.py
+++ b/src/osoji/observatory.py
@@ -21,7 +21,7 @@ from .scorecard import merge_ranges
 from .walker import discover_directories, discover_files
 
 OBSERVATORY_SCHEMA_NAME = "osoji-observatory"
-OBSERVATORY_SCHEMA_VERSION = "1.4.0"
+OBSERVATORY_SCHEMA_VERSION = "1.5.0"
 _DEFAULT_OUTPUT_NAME = "observatory.json"
 _SEVERITY_ORDER = {"error": 0, "warning": 1, "info": 2}
 

--- a/src/osoji/osoji-observatory.schema.json
+++ b/src/osoji/osoji-observatory.schema.json
@@ -677,6 +677,10 @@
           "description": "Triaged contract claims routed to the string-contract taxonomy's 'other' safety valve — the CE-gap numerator (V1-5c); null if --obligations not run.",
           "type": ["integer", "null"]
         },
+        "debris_untriaged": {
+          "description": "Kept debris findings that carried no Triage verdict this run (osoji#168 interim floor); null when the debris phase didn't run.",
+          "type": ["integer", "null"]
+        },
         "verdict_cache_hit_rate": {
           "description": "Fraction of Triage claims served from the incremental verdict cache this run (V1-9); null when no claims reached a Triage seam.",
           "type": ["number", "null"]

--- a/src/osoji/scorecard.py
+++ b/src/osoji/scorecard.py
@@ -74,6 +74,11 @@ class Scorecard:
     contract_claims_triaged: int | None = None
     contract_claims_other: int | None = None
 
+    # Untriaged-debris floor (osoji#168): kept debris findings that carried no
+    # Triage verdict this run (unclaimable, evidence gate unmet, or a failed
+    # decide chunk). None when the debris phase didn't run.
+    debris_untriaged: int | None = None
+
     # V1-9: fraction of Triage claims served from the incremental verdict
     # cache this run (None when no claims reached a Triage seam)
     verdict_cache_hit_rate: float | None = None

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -751,6 +751,85 @@ class TestTriageFieldsInJSON:
         assert payload["issues"][0]["confidence"] == 0.0
 
 
+class TestUntriagedDebrisFloor:
+    """osoji#168 interim floor: kept debris findings without a Triage verdict
+    are tagged [untriaged] in the report and counted on the scorecard."""
+
+    @staticmethod
+    def _issue(**over):
+        base = dict(
+            path=Path("src/x.py"), severity="error", category="dead_code",
+            message="L1-2: dead code", remediation="remove it",
+            exclude_key="debris",
+        )
+        base.update(over)
+        return AuditIssue(**base)
+
+    def test_error_untriaged_debris_is_tagged(self):
+        report = format_audit_report(AuditResult(issues=[self._issue()]))
+        assert "[untriaged]" in report
+
+    def test_error_triaged_debris_is_not_tagged(self):
+        report = format_audit_report(AuditResult(issues=[
+            self._issue(verdict="confirmed", confidence=0.9),
+        ]))
+        assert "[untriaged]" not in report
+
+    def test_warning_untriaged_debris_is_tagged(self):
+        report = format_audit_report(AuditResult(issues=[
+            self._issue(severity="warning"),
+        ]))
+        assert "[untriaged]" in report
+
+    def test_non_debris_verdictless_issue_is_not_tagged(self):
+        # Only the debris seam has a triage path; other phases' verdict-None
+        # issues are not "untriaged", they were never candidates.
+        report = format_audit_report(AuditResult(issues=[
+            self._issue(exclude_key="doc-analysis", category="doc_stale_content"),
+            self._issue(severity="warning", exclude_key="shadow", category="stale_shadow"),
+        ]))
+        assert "[untriaged]" not in report
+
+    def test_scorecard_row_renders_only_when_field_set(self):
+        with_field = format_audit_report(AuditResult(
+            issues=[], scorecard=_minimal_scorecard(debris_untriaged=3),
+        ))
+        assert "Untriaged debris" in with_field
+        assert "3" in with_field
+
+        without_field = format_audit_report(AuditResult(
+            issues=[], scorecard=_minimal_scorecard(),
+        ))
+        assert "Untriaged debris" not in without_field
+
+    def test_debris_untriaged_round_trips(self, temp_dir):
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        original = AuditResult(
+            issues=[], scorecard=_minimal_scorecard(debris_untriaged=2),
+        )
+        serialize_audit_result(config, original)
+        loaded = load_audit_result(config)
+        assert loaded.scorecard.debris_untriaged == 2
+
+    def test_debris_untriaged_absent_in_old_payload_loads_as_none(self, temp_dir):
+        from osoji.config import Config
+
+        config = Config(root_path=temp_dir, respect_gitignore=False)
+        serialize_audit_result(
+            config, AuditResult(issues=[], scorecard=_minimal_scorecard()),
+        )
+        # Simulate a pre-#168 payload: strip the key entirely.
+        result_path = config.analysis_root / "audit-result.json"
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+        payload["scorecard"].pop("debris_untriaged", None)
+        result_path.write_text(json.dumps(payload), encoding="utf-8")
+
+        loaded = load_audit_result(config)
+        assert loaded.scorecard.debris_untriaged is None
+
+
 class TestErrorReportSuggestedFix:
     """The Errors (blocking) markdown section surfaces the Triage suggested fix."""
 

--- a/tests/test_audit_debris_cutover.py
+++ b/tests/test_audit_debris_cutover.py
@@ -80,7 +80,9 @@ def test_dismissed_verdicts_suppress_correct_indices(temp_dir):
     config = Config(root_path=temp_dir, respect_gitignore=False)
     raw = [
         _debris("dead_code", "`old_helper` is defined but never used"),     # idx0 → claim0
-        _debris("commented_out_code", "a dead code block"),                 # idx1 ineligible
+        # idx1: eligible since #168, but src/x.py is not on disk and the
+        # description yields no needles → require_any unmet → pass-through.
+        _debris("commented_out_code", "a dead code block"),
         _debris("latent_bug", "`Foo` accessed but has no such attribute"),  # idx2 → claim1
     ]
     provider = FakeProvider(_verdicts_result([
@@ -91,7 +93,7 @@ def test_dismissed_verdicts_suppress_correct_indices(temp_dir):
     suppressed, phase_tokens, decided = _run(config, raw, provider)
 
     # Only the dismissed dead_code finding (raw index 0) is suppressed;
-    # the ineligible block (1) and the confirmed latent_bug (2) are kept.
+    # the unclaimable block (1) and the confirmed latent_bug (2) are kept.
     assert suppressed == {0}
     assert phase_tokens == (120, 60)
     assert provider.calls == 1
@@ -103,11 +105,14 @@ def test_dismissed_verdicts_suppress_correct_indices(temp_dir):
     assert decided[2].triage_reasoning == "real bug"
 
 
-def test_ineligible_only_makes_no_llm_call(temp_dir):
+def test_unclaimable_only_makes_no_llm_call(temp_dir):
+    # Since #168 every category is admitted, so the no-claims path is reached
+    # only when nothing is claimable: the flagged file is absent (description
+    # require_any=surrounding_code unmet) or the record carries no source.
     config = Config(root_path=temp_dir, respect_gitignore=False)
     raw = [
-        _debris("stale_comment", "comment is stale"),  # no cross_file flag → ineligible
-        _debris("misleading_docstring", "docstring drifted"),
+        _debris("stale_comment", "comment is stale"),  # src/x.py not on disk
+        _debris("misleading_docstring", "docstring drifted", source=None, source_path=None),
     ]
     provider = FakeProvider(_verdicts_result([]))
 
@@ -117,6 +122,38 @@ def test_ineligible_only_makes_no_llm_call(temp_dir):
     assert phase_tokens == (0, 0)
     assert provider.calls == 0
     assert decided == {}
+
+
+def test_description_family_reaches_triage_and_verdicts_land(temp_dir):
+    # THE #168 behavior change: unflagged stale_comment, misleading_docstring,
+    # expired_todo, and commented_out_code all build claims (real file on
+    # disk) and receive verdicts; dismissed ones suppress like any debris.
+    config = Config(root_path=temp_dir, respect_gitignore=False)
+    src = temp_dir / "src" / "x.py"
+    src.parent.mkdir(parents=True, exist_ok=True)
+    src.write_text("def helper():\n" + "    pass  # filler\n" * 13, encoding="utf-8")
+    raw = [
+        _debris("stale_comment", "comment says retries, code does not retry"),
+        _debris("misleading_docstring", "docstring describes removed behavior"),
+        _debris("expired_todo", "TODO(2024-01) remove after migration"),
+        _debris("commented_out_code", "a commented-out block kept around"),
+    ]
+    provider = FakeProvider(_verdicts_result([
+        {"batch_index": 0, "verdict": "dismissed", "confidence": 0.9,
+         "reasoning": "comment is accurate at module level"},
+        {"batch_index": 1, "verdict": "confirmed", "confidence": 0.85, "reasoning": "drifted"},
+        {"batch_index": 2, "verdict": "confirmed", "confidence": 0.8, "reasoning": "expired"},
+        {"batch_index": 3, "verdict": "confirmed", "confidence": 0.75, "reasoning": "debris"},
+    ]))
+
+    suppressed, phase_tokens, decided = _run(config, raw, provider)
+
+    assert provider.calls == 1
+    assert suppressed == {0}
+    assert set(decided.keys()) == {0, 1, 2, 3}
+    assert decided[1].verdict == "confirmed"
+    assert decided[3].verdict == "confirmed"
+    assert phase_tokens == (120, 60)
 
 
 def test_debris_corpus_is_decided_in_bounded_chunks(temp_dir):
@@ -251,10 +288,10 @@ def test_overlay_lands_on_kept_issues_end_to_end(temp_dir):
     """End-to-end (run_audit_async): a confirmed verdict's severity/suggested-fix
     /verdict/confidence/triage-reasoning land on the kept AuditIssue, additively
     (the heuristic remediation is unchanged); a dismissed verdict still
-    suppresses its finding entirely, exactly as before this migration; and a
-    finding with no decided counterpart at all (ineligible for Triage, never
-    built into a claim) keeps its heuristic severity with every Triage field
-    None — the overlay must not assume every kept finding was decided."""
+    suppresses its finding entirely, exactly as before this migration; and
+    since osoji#168 the description family is triaged too — the
+    commented_out_code finding carries a verdict instead of passing through,
+    and the scorecard's untriaged-debris floor reads zero."""
     _write(temp_dir, "src/x.py",
            "def old_helper():\n    pass\n\n\ndef also_dead():\n    pass\n# some old code\n")
     _write_findings(temp_dir, "src/x.py", [
@@ -278,6 +315,8 @@ def test_overlay_lands_on_kept_issues_end_to_end(temp_dir):
          "severity": "info"},
         {"batch_index": 1, "verdict": "dismissed", "confidence": 0.9,
          "reasoning": "actually used dynamically"},
+        {"batch_index": 2, "verdict": "confirmed", "confidence": 0.7,
+         "reasoning": "no reference keeps this block"},
     ]))
 
     with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
@@ -299,13 +338,70 @@ def test_overlay_lands_on_kept_issues_end_to_end(temp_dir):
     # The detector's heuristic remediation text stays put — additive, not replaced.
     assert issue.remediation == "Review and fix the identified issue"
 
-    # The ineligible finding was never built into a claim, so no decided
-    # Finding exists for it: heuristic severity survives, every Triage field
-    # stays None (not crashed on, not fabricated).
-    untriaged = next(i for i in debris_issues if "commented-out" in i.message)
-    assert untriaged.severity == "warning"
-    assert untriaged.finding_id is None
-    assert untriaged.verdict is None
-    assert untriaged.confidence is None
-    assert untriaged.triage_reasoning is None
-    assert untriaged.suggested_fix is None
+    # osoji#168: the description-family finding is triaged like everything
+    # else — a verdict lands instead of the old silent pass-through.
+    block = next(i for i in debris_issues if "commented-out" in i.message)
+    assert block.verdict == "confirmed"
+    assert block.confidence == 0.7
+    assert block.finding_id
+
+    # Every kept debris finding carried a verdict → the untriaged floor is 0.
+    assert result.scorecard is not None
+    assert result.scorecard.debris_untriaged == 0
+
+
+def test_untriaged_pass_through_is_counted_and_marked_end_to_end(temp_dir):
+    """The osoji#168 interim floor: a kept debris finding that never received a
+    verdict (here: a needle-less dead_code whose require_any gate was unmet)
+    is counted on the scorecard and tagged [untriaged] in the report."""
+    from osoji.audit import format_audit_report
+
+    _write(temp_dir, "src/x.py",
+           "def old_helper():\n    pass\n\n\n# unattributed block\npass\n")
+    _write_findings(temp_dir, "src/x.py", [
+        {
+            "category": "dead_code", "line_start": 1, "line_end": 2,
+            "severity": "warning", "description": "`old_helper` is defined but never used",
+        },
+        {
+            # No backticked/PascalCase needles → no cross_file_reference
+            # evidence gatherable → pass-through, kept unverified.
+            "category": "dead_code", "line_start": 5, "line_end": 6,
+            "severity": "warning", "description": "unused block of code",
+        },
+    ])
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = FakeProvider(_verdicts_result([
+        {"batch_index": 0, "verdict": "confirmed", "confidence": 0.9, "reasoning": "dead"},
+    ]))
+
+    with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, exclude={"shadow", "doc-analysis"},
+        ))
+
+    assert result.scorecard is not None
+    assert result.scorecard.debris_untriaged == 1
+
+    report = format_audit_report(result)
+    assert "[untriaged]" in report
+    assert "Untriaged debris" in report
+
+
+def test_untriaged_floor_is_none_when_debris_phase_excluded(temp_dir):
+    """None (not 0) when the debris phase didn't run — an excluded phase must
+    not read as a clean bill of health."""
+    config = Config(root_path=temp_dir, respect_gitignore=False, quiet=True)
+    provider = FakeProvider(_verdicts_result([]))
+
+    with patch("osoji.facts.FactsDB", return_value=FakeFacts()), \
+         patch("osoji.symbols.load_all_symbols", return_value={}), \
+         patch("osoji.audit.create_runtime", return_value=(provider, MagicMock())):
+        result = asyncio.run(run_audit_async(
+            config, fix_shadow=False, exclude={"shadow", "doc-analysis", "debris"},
+        ))
+
+    assert result.scorecard is not None
+    assert result.scorecard.debris_untriaged is None

--- a/tests/test_claim_builder.py
+++ b/tests/test_claim_builder.py
@@ -1,14 +1,14 @@
-"""Tests for the Claim Builder (V1-4 mechanized; V1-3 debris wrapper preserved).
+"""Tests for the Claim Builder (V1-4 mechanized).
 
 build_claims is the generalized schema-as-config pass: per finding category a
 SchemaEntry names the evidence kinds to build (in order) and the require_any
 sufficiency gate; the assembled bundle gets a deterministic evidence_fingerprint
-(schema version + impl hash + canonical bundle). build_debris_claims is now a
-thin wrapper preserving the V1-3 debris contract exactly: only eligible findings
-(dead_code / latent_bug always; stale_comment when flagged for cross-file check)
-with satisfiable evidence become Claims; the rest pass through untouched.
-Eligible-but-insufficient findings are *counted* (would_escalate) for the
-escalation-rate baseline but never escalated here.
+(schema version + impl hash + canonical bundle). Since osoji#168 the debris
+wrapper admits every debris category — the V1-3 eligibility gate and its
+DEBRIS_SCHEMA sufficiency overrides are retired. What survives of decision 0014
+is the pass-through semantics: findings whose require_any gate is unmet (or
+that carry no source at all) are *counted* (would_escalate) for the
+escalation-rate baseline but never escalated here; they ship kept-unverified.
 """
 
 import time
@@ -124,29 +124,64 @@ def test_eligible_with_refs_becomes_claim_with_evidence(config):
     assert xref.payload["references"][0]["file"] == "src/y.py"
 
 
-def test_ineligible_finding_is_not_a_claim(config):
-    facts = FakeFacts()
-    # stale_comment without the cross-file flag is ineligible (kept unverified)
+def _write_flagged_file(temp_dir):
+    """The description family's require_any is surrounding_code — the builder
+    reads the flagged file from disk, so these tests need a real one."""
+    target = temp_dir / "src" / "x.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "def helper():\n" + "    pass  # filler\n" * 13, encoding="utf-8"
+    )
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["stale_comment", "misleading_docstring", "expired_todo", "commented_out_code"],
+)
+def test_description_family_builds_claim_from_surrounding_code(config, temp_dir, category):
+    # osoji#168: every description-debris category routes through Triage; the
+    # deciding evidence is positional (surrounding_code), no cross-file ref
+    # required — single-file drift is exactly the population being triaged.
+    _write_flagged_file(temp_dir)
     claims, original_indices, would_escalate = build_debris_claims(
-        config, [debris(category="stale_comment", description="comment is stale")],
-        facts_db=facts, symbols_by_file={},
+        config,
+        [debris(category=category, description="the description contradicts the code")],
+        facts_db=FakeFacts(), symbols_by_file={},
+    )
+    assert len(claims) == 1
+    assert original_indices == [0]
+    assert would_escalate == 0
+    assert claims[0].insufficient_evidence is False
+    assert "surrounding_code" in [e.kind for e in claims[0].finding.evidence]
+
+
+def test_cross_file_flag_no_longer_gates_admission(config, temp_dir):
+    # The detector's cross_file_verification_needed flag is advisory context
+    # since osoji#168 (it rides in scanner_metadata); flagged and unflagged
+    # stale comments are admitted identically.
+    _write_flagged_file(temp_dir)
+    raw = [
+        debris(category="stale_comment", description="single-file drift"),
+        debris(category="stale_comment", description="`thing` no longer does X",
+               cross_file_verification_needed=True),
+    ]
+    claims, original_indices, _ = build_debris_claims(
+        config, raw, facts_db=FakeFacts(), symbols_by_file={}
+    )
+    assert len(claims) == 2
+    assert original_indices == [0, 1]
+
+
+def test_description_family_unreadable_file_counts_would_escalate(config):
+    # require_any={surrounding_code} unmet when the flagged file is gone:
+    # kept-unverified pass-through (decision 0014 semantics preserved).
+    claims, original_indices, would_escalate = build_debris_claims(
+        config, [debris(category="stale_comment", source="src/gone.py")],
+        facts_db=FakeFacts(), symbols_by_file={},
     )
     assert claims == []
     assert original_indices == []
-    assert would_escalate == 0
-
-
-def test_stale_comment_with_flag_is_eligible(config):
-    facts = FakeFacts({"thing": [
-        {"file": "src/z.py", "kind": "call", "context": "thing()", "resolves_to_source": False},
-    ]})
-    claims, original_indices, _ = build_debris_claims(
-        config,
-        [debris(category="stale_comment", description="`thing` no longer does X",
-                cross_file_verification_needed=True)],
-        facts_db=facts, symbols_by_file={},
-    )
-    assert len(claims) == 1
+    assert would_escalate == 1
 
 
 def test_eligible_without_evidence_counts_as_would_escalate(config):
@@ -159,19 +194,20 @@ def test_eligible_without_evidence_counts_as_would_escalate(config):
     assert would_escalate == 1
 
 
-def test_original_index_mapping_skips_non_candidates(config):
+def test_original_index_mapping_skips_pass_throughs(config):
     facts = FakeFacts({"old_helper": [
         {"file": "src/y.py", "kind": "import", "context": "import", "resolves_to_source": True},
     ]})
     raw = [
-        debris(category="commented_out_code", description="dead block"),  # ineligible
-        debris(),                                                          # eligible + refs
+        debris(source=None, source_path=None),  # malformed: no source → pass-through
+        debris(),                               # dead_code + refs → claim
     ]
-    claims, original_indices, _ = build_debris_claims(
+    claims, original_indices, would_escalate = build_debris_claims(
         config, raw, facts_db=facts, symbols_by_file={}
     )
     assert len(claims) == 1
     assert original_indices == [1]
+    assert would_escalate == 1
 
 
 def test_debris_wrapper_sets_fingerprint(config):
@@ -361,7 +397,22 @@ def test_schema_version_is_pinned():
     # scan_needles/priority_paths and flags in-string-literal hits.
     # cb-3 (V1-5d): doc-category schema keys unprefixed (doc_* → bare) so they
     # match category_of(finding_from_doc(...)) instead of falling to the default.
-    assert CLAIM_BUILDER_SCHEMA_VERSION == "cb-3"
+    # cb-4 (osoji#168): debris admission gate + DEBRIS_SCHEMA retired — all
+    # debris categories build on the general table; stale_comment loses its
+    # legacy cross_file_reference sufficiency override; expired_todo and
+    # commented_out_code gain description entries.
+    assert CLAIM_BUILDER_SCHEMA_VERSION == "cb-4"
+
+
+def test_debris_categories_all_have_explicit_schema_entries():
+    # osoji#168: the debris producer's closed category set (tools.py) resolves
+    # explicitly in the general table — no category rides the gap-type
+    # fallback silently.
+    for category in (
+        "dead_code", "stale_comment", "misleading_docstring",
+        "commented_out_code", "expired_todo", "latent_bug",
+    ):
+        assert category in CLAIM_BUILDER_SCHEMA, category
 
 
 def test_every_schema_kind_has_registered_builder():

--- a/tests/test_observatory.py
+++ b/tests/test_observatory.py
@@ -381,12 +381,13 @@ def test_bundle_doc_analysis_empty_when_no_docs(temp_dir):
     assert bundle["doc_analysis"] == {}
 
 
-def test_bundle_schema_version_is_1_4_0(temp_dir):
+def test_bundle_schema_version_is_1_5_0(temp_dir):
+    # 1.5.0 (osoji#168): scorecard gains the optional debris_untriaged field.
     _write_source(temp_dir, "main.py", "x = 1\n")
 
     bundle = build_observatory_bundle(temp_dir, respect_gitignore=False)
 
-    assert bundle["schema_version"] == "1.4.0"
+    assert bundle["schema_version"] == "1.5.0"
 
 
 def test_export_command_writes_bundle_file(temp_dir):
@@ -513,6 +514,8 @@ def test_full_bundle_validates_against_schema(temp_dir):
         "enforcement_by_schema": None,
         "obligation_violations": None,
         "obligation_implicit_contracts": None,
+        # osoji#168 (schema 1.5.0): untriaged-debris floor rides the bundle.
+        "debris_untriaged": 2,
     }
     _write_audit_result(
         temp_dir,


### PR DESCRIPTION
Fixes #168.

## What

Retires the V1-3 debris admission gate entirely: every category the debris detector emits (`stale_comment`, `misleading_docstring`, `commented_out_code`, `expired_todo`, `dead_code`, `latent_bug`) now builds a claim and routes through unified Triage. `_is_eligible` and `DEBRIS_SCHEMA` are deleted; the general `CLAIM_BUILDER_SCHEMA` gains `expired_todo` and `commented_out_code` entries (both `_DESCRIPTION_ENTRY`, matching what gap-type fallback already resolved). Schema version cb-3 → cb-4.

Interim floor from the ticket also ships: kept debris findings with no Triage verdict are tagged `[untriaged]` in the report and counted as `scorecard.debris_untriaged` (`None` when the debris phase didn't run). Observatory schema bumped 1.4.0 → 1.5.0 (additive optional field).

## Why full retirement (beyond the ticket's three categories)

After adding the named categories the gate would enumerate 5-of-6 and `DEBRIS_SCHEMA` would resolve identically to the general table — pure V1-3 compat residue. `commented_out_code` has a documented FP mode (detectors/0009 'reference-kept commented code') with no dismissal mechanism, the same disease the ticket measures at 60% for stale_comment. Wiki decisions/0014 review: the gate and DEBRIS_SCHEMA appear nowhere in the ruling (migration-era detail, explicitly revisable); the ruling-proper kept-unverified pass-through (`would_escalate`, dormant escalation) is preserved unchanged. Scope ruled by JF in-session.

## Key semantic change

`stale_comment` loses the legacy `require_any={cross_file_reference}` sufficiency override; the standard description entry (`require_any={surrounding_code}`) applies, so single-file comment-vs-code drift — exactly the measured 60%-FP population — becomes decidable. The detector's `cross_file_verification_needed` flag no longer gates anything; it remains advisory context (already threaded into scanner_metadata evidence, `findings_adapter.py`).

## No evaluator replay required

- `TRIAGE_SYSTEM_PROMPT` is byte-identical — `test_triage_sectioning.py` sha pin green.
- Corpus `evidence_policy: rebuild` cases build via `build_junk_claims` → `build_claims(schema=None)` → the general table, which is unchanged for every existing corpus category; the cb-4 fingerprint bump is cache-key-only (never in the LLM payload).

## Cost

On osoji's own live findings corpus (`scripts/measure_debris_cutover.py`): 86/86 debris findings now claim vs 38 previously — roughly double the phase-3 chunks (~8 vs ~4, BATCH_SIZE 12, medium tier). Steady state bounded by the V1-9 verdict cache; note cb-4 + impl-hash drift invalidate the cache once, so the first post-merge audit is full price.

## Coordination notes

- **work#91 (teams ingest)**: bundle schema is now 1.5.0 — the ingest work should target ≥1.5.0, not 1.4.0. The new field is optional/nullable; 1.4.0-shaped consumers that ignore unknown fields are unaffected.
- **Unblocks**: future audits write description-family verdicts into `decided-findings.json`, making the 47 blocked mcp-debugger sweep cases emittable after a re-audit (JF-gated spend) — feeds the corpus 90-non-gray gate.
- **Follow-on (PR B, work#81 + #31)**: dedicated description-debris rubric section (drift requirement, TODO actionability) — prompt change, corpus-replay gated, not this PR.

## Verification

- Full suite: 1504 passed, 14 skipped.
- New tests: family admission + would_escalate pass-throughs (test_claim_builder), family-reaches-Triage + untriaged floor end-to-end (test_audit_debris_cutover), report tag/scorecard row/round-trip (test_audit), schema 1.5.0 + bundle validation (test_observatory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)