### PR TITLE
Eval instrument: resample-disagreement metric (osojicode/work#92 follow-on, work#97)

### DIFF
--- a/scripts/corpus_replay.py
+++ b/scripts/corpus_replay.py
@@ -302,6 +302,21 @@ def main(argv: list[str] | None = None) -> int:
             # "runs/eval-xyz.ndjson" -> "runs/eval-xyz-traces.json"
             traces_out = Path(str(Path(args.out).with_suffix("")) + "-traces.json")
         write_exploration_traces(run, traces_out)
+
+    # Resample-disagreement summary (work#97). stderr so it never contaminates
+    # an NDJSON stream on ``--out -``; present only on repeats>=2 runs.
+    metrics = run.run_meta.get("metrics", {})
+    if "resample_flip_rate" in metrics:
+        print(
+            f"resample disagreement: flip_rate={metrics['resample_flip_rate']:.3f} "
+            f"agree_rate={metrics['resample_agree_rate']:.3f}",
+            file=sys.stderr,
+        )
+        for flagged in metrics.get("resample_flagged_cases", []):
+            print(
+                f"  unstable: {flagged['case']} [{flagged['variant']}] {flagged['verdicts']}",
+                file=sys.stderr,
+            )
     return 0
 
 

--- a/scripts/eval_lib.py
+++ b/scripts/eval_lib.py
@@ -29,6 +29,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+from collections import Counter
 from collections.abc import Callable, Collection
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -439,6 +440,11 @@ def compute_metrics(records: list[dict], cases: list[CorpusCase]) -> dict:
     and ``accuracy_nongray`` exclude gray cases; the remaining metrics do not
     (``ce_gap_gap_type`` and ``me_overlap`` are computed statically from
     ``cases``, independent of any particular run).
+
+    When any ``(variant, case)`` group holds >=2 records (a repeats>=2 run),
+    three resample-disagreement keys are additionally emitted
+    (``resample_flip_rate``, ``resample_agree_rate``,
+    ``resample_flagged_cases``); at repeats=1 they are absent, not 0.0.
     """
 
     nongray = [r for r in records if not r.get("gray")]
@@ -518,7 +524,37 @@ def compute_metrics(records: list[dict], cases: list[CorpusCase]) -> dict:
     for c in cases:
         n_cases_by_category[c.category] = n_cases_by_category.get(c.category, 0) + 1
 
+    # Resample disagreement (osojicode/work#97): per-case verdict agreement
+    # across repeats, grouped by (variant, case). Emitted ONLY when at least
+    # one group has >=2 records — at repeats=1 the keys are absent entirely,
+    # so a future evaluate-baseline.json bound stays inert (check_thresholds
+    # skips absent metrics) and self-arms the moment a run uses repeats>=2.
+    # Emitting 0.0 instead would falsely read as "perfectly stable".
+    # NB: "any disagreement" (flip) is monotonically nondecreasing in the
+    # repeat count, so a flip-rate threshold is only meaningful at a pinned
+    # repeats value. None verdicts count as their own category — an undecided
+    # repeat disagreeing with a decided one IS instability.
+    verdict_groups: dict[tuple[str, str], list] = {}
+    for r in records:
+        verdict_groups.setdefault((r.get("variant"), r.get("case")), []).append(r.get("verdict"))
+    multi = {k: v for k, v in verdict_groups.items() if len(v) >= 2}
+    resample: dict[str, Any] = {}
+    if multi:
+        flips = {k: v for k, v in multi.items() if len(set(v)) > 1}
+        resample = {
+            "resample_flip_rate": len(flips) / len(multi),
+            "resample_agree_rate": sum(
+                Counter(v).most_common(1)[0][1] / len(v) for v in multi.values()
+            )
+            / len(multi),
+            "resample_flagged_cases": [
+                {"variant": variant, "case": case, "verdicts": dict(Counter(map(str, v)))}
+                for (variant, case), v in sorted(flips.items())
+            ],
+        }
+
     return {
+        **resample,
         "tp_rate": tp_rate,
         "tp_rate_by_detector": tp_rate_by_detector,
         "fp_rate": fp_rate,

--- a/tests/test_eval_lib.py
+++ b/tests/test_eval_lib.py
@@ -30,6 +30,7 @@ from eval_lib import (  # noqa: E402
     build_case_claim,
     cases_from_bootstrap_manifest,
     check_gepa_gate,
+    check_thresholds,
     compute_metrics,
     evaluate_corpus,
     load_corpus,
@@ -857,6 +858,102 @@ def test_compute_metrics_empty_inputs_do_not_crash():
     assert metrics["me_overlap"] == 0.0
     assert metrics["escalation_rate"] == 0.0
     assert metrics["n_cases"] == 0
+
+
+def test_compute_metrics_resample_disagreement_across_repeats():
+    # Two variants x three repeats over two cases. In variant "a", case c1
+    # flips (confirmed/confirmed/dismissed) while c2 is stable; variant "b"
+    # is stable on both. 1 flipping group out of 4 multi-record groups.
+    records = [
+        _rec(variant="a", case="c1", repeat=0, verdict="confirmed"),
+        _rec(variant="a", case="c1", repeat=1, verdict="confirmed"),
+        _rec(variant="a", case="c1", repeat=2, verdict="dismissed"),
+        _rec(variant="a", case="c2", repeat=0, verdict="dismissed"),
+        _rec(variant="a", case="c2", repeat=1, verdict="dismissed"),
+        _rec(variant="a", case="c2", repeat=2, verdict="dismissed"),
+        _rec(variant="b", case="c1", repeat=0, verdict="confirmed"),
+        _rec(variant="b", case="c1", repeat=1, verdict="confirmed"),
+        _rec(variant="b", case="c1", repeat=2, verdict="confirmed"),
+        _rec(variant="b", case="c2", repeat=0, verdict="uncertain"),
+        _rec(variant="b", case="c2", repeat=1, verdict="uncertain"),
+        _rec(variant="b", case="c2", repeat=2, verdict="uncertain"),
+    ]
+
+    metrics = compute_metrics(records, [])
+
+    assert metrics["resample_flip_rate"] == pytest.approx(1 / 4)
+    # Agree rates per group: c1/a 2/3, c2/a 1.0, c1/b 1.0, c2/b 1.0.
+    assert metrics["resample_agree_rate"] == pytest.approx((2 / 3 + 1.0 + 1.0 + 1.0) / 4)
+    assert metrics["resample_flagged_cases"] == [
+        {"variant": "a", "case": "c1", "verdicts": {"confirmed": 2, "dismissed": 1}},
+    ]
+
+
+def test_compute_metrics_resample_keys_absent_at_single_repeat():
+    # A repeats=1 run: every (variant, case) group has one record, so the
+    # resample keys must be ABSENT (not 0.0) — a pinned baseline bound stays
+    # inert until a run actually resamples.
+    records = [
+        _rec(variant="a", case="c1", repeat=0),
+        _rec(variant="a", case="c2", repeat=0),
+        _rec(variant="b", case="c1", repeat=0),
+    ]
+
+    metrics = compute_metrics(records, [])
+
+    assert "resample_flip_rate" not in metrics
+    assert "resample_agree_rate" not in metrics
+    assert "resample_flagged_cases" not in metrics
+
+
+def test_compute_metrics_resample_none_verdict_is_its_own_category():
+    # An undecided repeat disagreeing with a decided one IS instability.
+    records = [
+        _rec(variant="a", case="c1", repeat=0, verdict="confirmed"),
+        _rec(variant="a", case="c1", repeat=1, verdict=None),
+    ]
+
+    metrics = compute_metrics(records, [])
+
+    assert metrics["resample_flip_rate"] == 1.0
+    assert metrics["resample_flagged_cases"] == [
+        {"variant": "a", "case": "c1", "verdicts": {"confirmed": 1, "None": 1}},
+    ]
+
+
+def test_compute_metrics_resample_mixed_repeat_counts():
+    # Single-record groups are excluded from the denominator; only groups
+    # with >=2 records count.
+    records = [
+        _rec(variant="a", case="c1", repeat=0, verdict="confirmed"),
+        _rec(variant="a", case="c1", repeat=1, verdict="dismissed"),
+        _rec(variant="a", case="c2", repeat=0, verdict="confirmed"),
+    ]
+
+    metrics = compute_metrics(records, [])
+
+    assert metrics["resample_flip_rate"] == 1.0
+    assert metrics["resample_agree_rate"] == pytest.approx(0.5)
+
+
+def test_check_thresholds_resample_flip_rate_gateable_and_self_arming():
+    baseline = {"resample_flip_rate": {"max": 0.13}}
+
+    # Present and above the bound -> violation.
+    violations = check_thresholds({"resample_flip_rate": 0.25}, baseline)
+    assert violations and "resample_flip_rate" in violations[0]
+
+    # Present and within the bound -> clean.
+    assert check_thresholds({"resample_flip_rate": 0.10}, baseline) == []
+
+    # Absent (repeats=1 run) -> silently skipped: the bound is self-arming.
+    assert check_thresholds({"tp_rate": 0.9}, baseline) == []
+
+    # The non-scalar detail list is never compared against bounds.
+    assert check_thresholds(
+        {"resample_flagged_cases": [{"case": "c1"}]},
+        {"resample_flagged_cases": {"max": 0.0}},
+    ) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements osojicode/work#97: per-case verdict agreement across repeats as a mechanical ambiguity/gray signal, eval-time only.

- `compute_metrics` groups verdict records by `(variant, case)` and, when any group holds >=2 records, emits `resample_flip_rate` (fraction of multi-repeat groups whose verdicts are not all identical), `resample_agree_rate` (mean modal-verdict share), and `resample_flagged_cases` (per-group verdict counts for every disagreeing group).
- **Keys are absent at repeats=1, not 0.0** — `check_thresholds` skips absent metrics, so a future `evaluate-baseline.json` bound is inert on the standard 1-repeat gate and self-arms the moment a run resamples. Emitting 0.0 would falsely read as "perfectly stable".
- `None` verdicts count as their own category: an undecided repeat disagreeing with a decided one is instability.
- `corpus_replay.py` prints a stderr summary (never contaminates `--out -` NDJSON) with the flagged-case list.

## Deliberately not in this PR

- **No baseline entry (observe-only).** The measured 13.5% churn floor (`ab-descfam-report.md`) is a cross-run quantity (two 1-repeat runs); the within-run repeat disagreement this metric measures is related but unmeasured. The first repeats>=3 replay (scheduled with the work#95/#80 acceptance runs) pins `resample_flip_rate.max` in a one-line follow-up.
- No production resampling (2–3× cost/finding; explicitly out of scope per the ticket).

## Uses

1. Mechanical proxy for the human `gray` flag when triaging corpus candidates.
2. Candidate ambiguity evidence for the 0029 ambiguous-description class (work#94).
3. Repeat-verification of borderline single-shot baseline verdicts (the 167/208 lesson).

## Testing

- 5 new unit tests: exact flip/agree values over 2 variants × 3 repeats, key absence at repeats=1, None-as-category, mixed repeat counts, threshold interplay (gateable when present, silently skipped when absent, non-scalar detail never compared).
- Full suite: 1511 passed + prompt_regression 9 passed locally.

Refs osojicode/work#97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)