### PR TITLE
pin resample_flip_rate max 0.15 (osojicode/work#97 follow-up)

### DIFF
--- a/tests/fixtures/prompt_regression/evaluate-baseline.json
+++ b/tests/fixtures/prompt_regression/evaluate-baseline.json
@@ -19,5 +19,8 @@
   },
   "me_overlap": {
     "max": 0.05
+  },
+  "resample_flip_rate": {
+    "max": 0.15
   }
 }


### PR DESCRIPTION
First within-run measurement: 6/62 = 9.7% any-disagreement at repeats=3 on
the descfam slice (ab-cb5-report.md), below the 13.5% cross-run churn floor.
Pin at measured + margin. Inert on the repeats=1 gate (the metric keys are
absent, check_thresholds skips absent metrics) and self-arms on any
resampled replay; the flip metric is monotone in repeats, so the bound is
meaningful at the measured repeat count.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
